### PR TITLE
FEAT: 닉네임 중복 검사 기능 구현 

### DIFF
--- a/src/main/java/com/my/relink/controller/user/UserController.java
+++ b/src/main/java/com/my/relink/controller/user/UserController.java
@@ -2,8 +2,10 @@ package com.my.relink.controller.user;
 
 import com.my.relink.config.security.AuthUser;
 import com.my.relink.controller.user.dto.req.UserCreateReqDto;
+import com.my.relink.controller.user.dto.req.UserValidNicknameRepDto;
 import com.my.relink.controller.user.dto.resp.UserCreateRespDto;
 import com.my.relink.controller.user.dto.resp.UserInfoRespDto;
+import com.my.relink.controller.user.dto.resp.UserValidNicknameRespDto;
 import com.my.relink.service.UserService;
 import com.my.relink.util.api.ApiResult;
 import jakarta.validation.Valid;
@@ -34,5 +36,12 @@ public class UserController {
         return ResponseEntity
                 .status(HttpStatus.OK)
                 .body(ApiResult.success(userService.findUserInfo(authUser.getEmail())));
+    }
+
+    @GetMapping("/users/check-nickname")
+    public ResponseEntity<ApiResult<UserValidNicknameRespDto>> duplicatedNickname(
+            @Valid @RequestBody UserValidNicknameRepDto dto
+    ) {
+        return ResponseEntity.status(HttpStatus.OK).body(ApiResult.success(userService.validNickname(dto)));
     }
 }

--- a/src/main/java/com/my/relink/controller/user/dto/req/UserValidNicknameRepDto.java
+++ b/src/main/java/com/my/relink/controller/user/dto/req/UserValidNicknameRepDto.java
@@ -1,0 +1,19 @@
+package com.my.relink.controller.user.dto.req;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.validator.constraints.Length;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class UserValidNicknameRepDto {
+
+    @NotBlank(message = "닉네임을 적어주세요.")
+    @Length(max = 20, message = "닉네임은 최대 20자까지 입니다.")
+    private String nickname;
+}

--- a/src/main/java/com/my/relink/controller/user/dto/resp/UserValidNicknameRespDto.java
+++ b/src/main/java/com/my/relink/controller/user/dto/resp/UserValidNicknameRespDto.java
@@ -1,0 +1,10 @@
+package com.my.relink.controller.user.dto.resp;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class UserValidNicknameRespDto {
+    private boolean duplicated;
+}

--- a/src/main/java/com/my/relink/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/my/relink/domain/user/repository/UserRepository.java
@@ -7,4 +7,6 @@ import java.util.Optional;
 
 public interface UserRepository extends JpaRepository<User, Long> {
     Optional<User> findByEmail(String email);
+
+    Optional<User> findByNickname(String nickname);
 }

--- a/src/main/java/com/my/relink/service/UserService.java
+++ b/src/main/java/com/my/relink/service/UserService.java
@@ -1,5 +1,7 @@
 package com.my.relink.service;
 
+import com.my.relink.controller.user.dto.req.UserValidNicknameRepDto;
+import com.my.relink.controller.user.dto.resp.UserValidNicknameRespDto;
 import com.my.relink.domain.image.EntityType;
 import com.my.relink.domain.image.Image;
 import com.my.relink.domain.image.ImageRepository;
@@ -35,5 +37,9 @@ public class UserService {
         Image image = imageRepository.findByEntityIdAndEntityType(user.getId(), EntityType.USER).orElse(null);
 
         return new UserInfoRespDto(user, image);
+    }
+
+    public UserValidNicknameRespDto validNickname(UserValidNicknameRepDto dto) {
+        return new UserValidNicknameRespDto(userRepository.findByNickname(dto.getNickname()).isPresent());
     }
 }

--- a/src/test/java/com/my/relink/service/UserServiceTest.java
+++ b/src/test/java/com/my/relink/service/UserServiceTest.java
@@ -1,5 +1,7 @@
 package com.my.relink.service;
 
+import com.my.relink.controller.user.dto.req.UserValidNicknameRepDto;
+import com.my.relink.controller.user.dto.resp.UserValidNicknameRespDto;
 import com.my.relink.domain.image.EntityType;
 import com.my.relink.domain.image.Image;
 import com.my.relink.domain.image.ImageRepository;
@@ -23,8 +25,7 @@ import java.util.Optional;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
 class UserServiceTest {
@@ -153,5 +154,43 @@ class UserServiceTest {
 
         verify(userRepository).findByEmail(email);
         verify(imageRepository).findByEntityIdAndEntityType(user.getId(), EntityType.USER);
+    }
+
+    @Test
+    @DisplayName("닉네임이 중복일 때 Duplicated는 true를 반환한다.")
+    void validNicknameDuplicatedIsTrueSuccessTest(){
+        // given
+        UserValidNicknameRepDto repDto = UserValidNicknameRepDto.builder()
+                .nickname("test")
+                .build();
+
+        User user = User.builder()
+                .nickname("test")
+                .build();
+
+        when(userRepository.findByNickname(repDto.getNickname())).thenReturn(Optional.of(user));
+        // when
+        UserValidNicknameRespDto respDto = userService.validNickname(repDto);
+
+        // then
+        assertThat(respDto.isDuplicated()).isTrue();
+        verify(userRepository, times(1)).findByNickname(any());
+    }
+
+    @Test
+    @DisplayName("닉네임이 중복일 때 Duplicated는 false를 반환한다.")
+    void validNicknameDuplicatedIsFalseSuccessTest(){
+        // given
+        UserValidNicknameRepDto repDto = UserValidNicknameRepDto.builder()
+                .nickname("test")
+                .build();
+
+        when(userRepository.findByNickname(repDto.getNickname())).thenReturn(Optional.empty());
+        // when
+        UserValidNicknameRespDto respDto = userService.validNickname(repDto);
+
+        // then
+        assertThat(respDto.isDuplicated()).isFalse();
+        verify(userRepository, times(1)).findByNickname(any());
     }
 }


### PR DESCRIPTION
## 💫 PR 개요
닉네임 중복 검사 

## 📌 관련 이슈
<!-- 이슈 연결 -->
- OPEN #47 

## 🛠 작업 내용
<!-- 구현한 내용을 자세히 설명 (시나리오나 구현 이유 등) -->
1. 요청으로 들어온 닉네임으로 DB 조회 후 중복여부를 응답합니다. 

## 리뷰 요청 사항


## 체크리스트
<!-- PR을 생성하기 전에 확인해야 할 사항들 -->
- [ ] 코드 컨벤션을 준수하였습니다
- [ ] 커밋 메시지를 컨벤션에 맞게 작성하였습니다
- [ ] conflict가 모두 해결되었습니다
- [ ] 테스트 코드를 작성하였습니다
- [ ] self review를 진행하였습니다