### PR TITLE
Feat : 교환 수락 시 주소지 입력 받기

### DIFF
--- a/src/main/java/com/my/relink/controller/trade/TradeController.java
+++ b/src/main/java/com/my/relink/controller/trade/TradeController.java
@@ -1,6 +1,8 @@
 package com.my.relink.controller.trade;
 
 import com.my.relink.config.security.AuthUser;
+import com.my.relink.controller.trade.dto.request.AddressReqDto;
+import com.my.relink.controller.trade.dto.response.AddressRespDto;
 import com.my.relink.controller.trade.dto.response.TradeInquiryDetailRespDto;
 import com.my.relink.controller.trade.dto.response.TradeRequestRespDto;
 import com.my.relink.service.TradeService;
@@ -36,6 +38,12 @@ public class TradeController {
     public ResponseEntity<Void> cancelTradeRequest(@PathVariable(name = "tradeId") Long tradeId, @AuthenticationPrincipal AuthUser authUser) {
         tradeService.cancelTradeRequest(tradeId, authUser);
         return ResponseEntity.noContent().build();
+    }
+
+    @PostMapping("/trades/{tradeId}/completion/address")
+    public ResponseEntity<ApiResult<AddressRespDto>> createAddress(@PathVariable(name = "tradeId") Long tradeId, @RequestBody AddressReqDto reqDto, @AuthenticationPrincipal AuthUser authUser){
+        AddressRespDto responseDto = tradeService.createAddress(tradeId, reqDto, authUser);
+        return new ResponseEntity<>(ApiResult.success(responseDto), HttpStatus.CREATED);
     }
 
 }

--- a/src/main/java/com/my/relink/controller/trade/dto/request/AddressReqDto.java
+++ b/src/main/java/com/my/relink/controller/trade/dto/request/AddressReqDto.java
@@ -1,0 +1,43 @@
+package com.my.relink.controller.trade.dto.request;
+
+import com.my.relink.domain.user.Address;
+import jakarta.persistence.Column;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.hibernate.validator.constraints.Length;
+
+@Getter
+@AllArgsConstructor
+public class AddressReqDto {
+
+    @NotNull(message = "우편번호를 적어주세요.")
+    @Min(value = 10000, message = "우편번호 형식이 아닙니다.")
+    @Max(value = 99999, message = "우편번호 형식이 아닙니다.")
+    private Integer zipcode;
+
+    @NotBlank(message = "기본 주소지를 입력해주세요.")
+    @Length(max = 30, message = "기본 주소지는 30자까지 입니다.")
+    @Column(length = 30)
+    private String baseAddress;
+
+    @NotBlank(message = "상세 주소지를 입력해주세요.")
+    @Length(max = 100, message = "상세 주소지는 100자까지 입니다.")
+    @Column(length = 100)
+    private String detailAddress;
+
+        public Address toOwnerAddressEntity() {
+        return new Address(zipcode, baseAddress, detailAddress);
+    }
+
+    public Address toRequesterAddressEntity() {
+        return new Address(zipcode, baseAddress, detailAddress);
+    }
+    public Address toAddressEntity() {
+        return new Address(zipcode, baseAddress, detailAddress);
+    }
+
+}

--- a/src/main/java/com/my/relink/controller/trade/dto/response/AddressRespDto.java
+++ b/src/main/java/com/my/relink/controller/trade/dto/response/AddressRespDto.java
@@ -1,0 +1,10 @@
+package com.my.relink.controller.trade.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class AddressRespDto {
+    private Long tradeId;
+}

--- a/src/main/java/com/my/relink/domain/point/pointHistory/repository/PointHistoryRepository.java
+++ b/src/main/java/com/my/relink/domain/point/pointHistory/repository/PointHistoryRepository.java
@@ -8,5 +8,5 @@ import java.util.Optional;
 
 @Repository
 public interface PointHistoryRepository extends JpaRepository<PointHistory, Long> {
-    Optional<PointHistory> findByTradeIdOrderByCreatedAtDesc(Long tradeId);
+    Optional<PointHistory> findFirstByTradeIdOrderByCreatedAtDesc(Long tradeId);
 }

--- a/src/main/java/com/my/relink/domain/trade/Trade.java
+++ b/src/main/java/com/my/relink/domain/trade/Trade.java
@@ -105,4 +105,11 @@ public class Trade extends BaseEntity {
         this.hasRequesterRequested = requestedStatus;
     }
 
+    public void saveOwnerAddress(Address newAddress) {
+        this.ownerAddress = newAddress;
+    }
+
+    public void saveRequesterAddress(Address newAddress) {
+        this.requesterAddress = newAddress;
+    }
 }

--- a/src/main/java/com/my/relink/service/PointTransactionService.java
+++ b/src/main/java/com/my/relink/service/PointTransactionService.java
@@ -25,7 +25,7 @@ public class PointTransactionService {
     @Transactional
     public void restorePoints(Long tradeId, AuthUser authUser){
         // 해당 Trade에 연결된 PointHistory 확인
-        PointHistory pointHistory = pointHistoryRepository.findByTradeIdOrderByCreatedAtDesc(tradeId)
+        PointHistory pointHistory = pointHistoryRepository.findFirstByTradeIdOrderByCreatedAtDesc(tradeId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.POINT_HISTORY_NOT_FOUND));
 
         Point point = pointRepository.findByUserId(authUser.getId())

--- a/src/main/java/com/my/relink/service/TradeService.java
+++ b/src/main/java/com/my/relink/service/TradeService.java
@@ -1,11 +1,14 @@
 package com.my.relink.service;
 
 import com.my.relink.config.security.AuthUser;
+import com.my.relink.controller.trade.dto.request.AddressReqDto;
+import com.my.relink.controller.trade.dto.response.AddressRespDto;
 import com.my.relink.controller.trade.dto.response.TradeInquiryDetailRespDto;
 import com.my.relink.controller.trade.dto.response.TradeRequestRespDto;
 import com.my.relink.domain.trade.Trade;
 import com.my.relink.domain.trade.TradeStatus;
 import com.my.relink.domain.trade.repository.TradeRepository;
+import com.my.relink.domain.user.Address;
 import com.my.relink.domain.user.User;
 import com.my.relink.domain.user.repository.UserRepository;
 import com.my.relink.ex.BusinessException;
@@ -98,5 +101,29 @@ public class TradeService {
             tradeRepository.save(trade);
         }
     }
+
+    @Transactional
+    public AddressRespDto createAddress(Long tradeId, AddressReqDto reqDto, AuthUser authUser) {
+        User currentUser = userRepository.findById(authUser.getId())
+                .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
+
+        Trade trade = tradeRepository.findById(tradeId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.TRADE_NOT_FOUND));
+
+        // 소유자 주소와 요청자 주소 업데이트
+        if(trade.getRequester().getId().equals(currentUser.getId())){
+            Address requesterAddress = reqDto.toRequesterAddressEntity();  // 요청자 주소 생성
+            trade.saveRequesterAddress(requesterAddress);
+            //trade.saveOwnerAddress(reqDto.toOwnerAddressEntity());
+        } else{
+            Address requesterAddress = reqDto.toRequesterAddressEntity();  // 요청자 주소 생성
+            trade.saveRequesterAddress(requesterAddress);
+            //trade.saveRequesterAddress(reqDto.toRequesterAddressEntity());
+        }
+
+        tradeRepository.save(trade);
+        return new AddressRespDto(tradeId);
+    }
+
 }
 

--- a/src/main/java/com/my/relink/service/TradeService.java
+++ b/src/main/java/com/my/relink/service/TradeService.java
@@ -115,11 +115,9 @@ public class TradeService {
             if(trade.getRequester().getId().equals(currentUser.getId())){
                 Address requesterAddress = reqDto.toRequesterAddressEntity();  // 요청자 주소 생성
                 trade.saveRequesterAddress(requesterAddress);
-                //trade.saveOwnerAddress(reqDto.toOwnerAddressEntity());
             } else{
-                Address requesterAddress = reqDto.toRequesterAddressEntity();  // 요청자 주소 생성
-                trade.saveRequesterAddress(requesterAddress);
-                //trade.saveRequesterAddress(reqDto.toRequesterAddressEntity());
+                Address ownerAddress = reqDto.toOwnerAddressEntity();  // 소유자 주소 생성
+                trade.saveRequesterAddress(ownerAddress);
             }
 
             tradeRepository.save(trade);

--- a/src/main/java/com/my/relink/service/TradeService.java
+++ b/src/main/java/com/my/relink/service/TradeService.java
@@ -117,7 +117,7 @@ public class TradeService {
                 trade.saveRequesterAddress(requesterAddress);
             } else{
                 Address ownerAddress = reqDto.toOwnerAddressEntity();  // 소유자 주소 생성
-                trade.saveRequesterAddress(ownerAddress);
+                trade.saveOwnerAddress(ownerAddress);
             }
 
             tradeRepository.save(trade);

--- a/src/main/java/com/my/relink/service/TradeService.java
+++ b/src/main/java/com/my/relink/service/TradeService.java
@@ -110,20 +110,23 @@ public class TradeService {
         Trade trade = tradeRepository.findById(tradeId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.TRADE_NOT_FOUND));
 
-        // 소유자 주소와 요청자 주소 업데이트
-        if(trade.getRequester().getId().equals(currentUser.getId())){
-            Address requesterAddress = reqDto.toRequesterAddressEntity();  // 요청자 주소 생성
-            trade.saveRequesterAddress(requesterAddress);
-            //trade.saveOwnerAddress(reqDto.toOwnerAddressEntity());
-        } else{
-            Address requesterAddress = reqDto.toRequesterAddressEntity();  // 요청자 주소 생성
-            trade.saveRequesterAddress(requesterAddress);
-            //trade.saveRequesterAddress(reqDto.toRequesterAddressEntity());
+        if(trade.getHasOwnerRequested()&&trade.getHasRequesterRequested()){
+            // 소유자 주소와 요청자 주소 업데이트
+            if(trade.getRequester().getId().equals(currentUser.getId())){
+                Address requesterAddress = reqDto.toRequesterAddressEntity();  // 요청자 주소 생성
+                trade.saveRequesterAddress(requesterAddress);
+                //trade.saveOwnerAddress(reqDto.toOwnerAddressEntity());
+            } else{
+                Address requesterAddress = reqDto.toRequesterAddressEntity();  // 요청자 주소 생성
+                trade.saveRequesterAddress(requesterAddress);
+                //trade.saveRequesterAddress(reqDto.toRequesterAddressEntity());
+            }
+
+            tradeRepository.save(trade);
+            return new AddressRespDto(tradeId);
+        } else {
+            throw new BusinessException(ErrorCode.TRADE_ACCESS_DENIED);
         }
-
-        tradeRepository.save(trade);
-        return new AddressRespDto(tradeId);
     }
-
 }
 


### PR DESCRIPTION
## 💫 PR 개요
<!-- PR에 대한 간단한 설명 -->
거래에 대한 소유자, 요청자 모두 교환 신청을 누르면 주소지를 입력 받는다.
## 📌 관련 이슈
<!-- 이슈 연결 -->
- Closes #14 
- Resolves #14 

## 🛠 작업 내용
<!-- 구현한 내용을 자세히 설명 (시나리오나 구현 이유 등) -->
1. 거래 요청자와 소유자의 requested 필드가 true인지 확인
2. 로그인한 유저와 요청자의 아이디가 같으면 requesterAddress에 주소 입력받고 저장
3. 로그인한 유저와 소유자의 아이디가 같으면 ownerAddress에 주소 입력받고 저장
4. 거래 요청자와 소유자의 requested 필드가 모두 true가 아니면 예외 발생
5. 
## 리뷰 요청 사항
<!-- 리뷰어가 특별히 봐주었으면 하는 부분을 작성! -->

## 체크리스트
<!-- PR을 생성하기 전에 확인해야 할 사항들 -->
- [x] 코드 컨벤션을 준수하였습니다
- [x] 커밋 메시지를 컨벤션에 맞게 작성하였습니다
- [ ] conflict가 모두 해결되었습니다
- [ ] 테스트 코드를 작성하였습니다
- [x] self review를 진행하였습니다