### PR TITLE
FEAT: 웹소켓 커넥션 설정 및 검증 추가

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,4 @@ out/
 ### VS Code ###
 .vscode/
 ReLinkApplication.java
+application-local.yaml

--- a/.gitignore
+++ b/.gitignore
@@ -35,5 +35,4 @@ out/
 
 ### VS Code ###
 .vscode/
-application-dev.yaml
 ReLinkApplication.java

--- a/src/main/java/com/my/relink/chat/config/ChatPrincipal.java
+++ b/src/main/java/com/my/relink/chat/config/ChatPrincipal.java
@@ -1,0 +1,2 @@
+package com.my.relink.chat.config;public class ChatPrincipal {
+}

--- a/src/main/java/com/my/relink/chat/config/ChatPrincipal.java
+++ b/src/main/java/com/my/relink/chat/config/ChatPrincipal.java
@@ -1,2 +1,20 @@
-package com.my.relink.chat.config;public class ChatPrincipal {
+package com.my.relink.chat.config;
+
+import com.my.relink.config.security.AuthUser;
+import lombok.Getter;
+import java.security.Principal;
+
+@Getter
+public class ChatPrincipal implements Principal {
+
+    private final AuthUser authUser;
+
+    public ChatPrincipal(AuthUser authUser) {
+        this.authUser = authUser;
+    }
+
+    @Override
+    public String getName() {
+        return authUser.getId().toString();
+    }
 }

--- a/src/main/java/com/my/relink/chat/config/WebSocketConfig.java
+++ b/src/main/java/com/my/relink/chat/config/WebSocketConfig.java
@@ -1,0 +1,19 @@
+package com.my.relink.chat.config;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.messaging.simp.config.MessageBrokerRegistry;
+import org.springframework.web.socket.config.annotation.EnableWebSocketMessageBroker;
+import org.springframework.web.socket.config.annotation.WebSocketMessageBrokerConfigurer;
+
+@Configuration
+@EnableWebSocketMessageBroker
+@RequiredArgsConstructor
+public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
+
+    @Override
+    public void configureMessageBroker(MessageBrokerRegistry registry) {
+        registry.enableSimpleBroker("/sub"); //구독하는 쪽
+        registry.setApplicationDestinationPrefixes("/app");
+    }
+}

--- a/src/main/java/com/my/relink/chat/config/WebSocketConfig.java
+++ b/src/main/java/com/my/relink/chat/config/WebSocketConfig.java
@@ -1,19 +1,51 @@
 package com.my.relink.chat.config;
 
+import com.my.relink.chat.handler.StompHandler;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.messaging.simp.config.ChannelRegistration;
 import org.springframework.messaging.simp.config.MessageBrokerRegistry;
 import org.springframework.web.socket.config.annotation.EnableWebSocketMessageBroker;
+import org.springframework.web.socket.config.annotation.StompEndpointRegistry;
 import org.springframework.web.socket.config.annotation.WebSocketMessageBrokerConfigurer;
 
 @Configuration
-@EnableWebSocketMessageBroker
+@EnableWebSocketMessageBroker //STOMP 활성화
 @RequiredArgsConstructor
 public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
 
+    private final StompHandler stompHandler;
+
+    /**
+     * 메시지 브로커 설정
+     * @param registry
+     */
     @Override
     public void configureMessageBroker(MessageBrokerRegistry registry) {
-        registry.enableSimpleBroker("/sub"); //구독하는 쪽
-        registry.setApplicationDestinationPrefixes("/app");
+        registry.enableSimpleBroker("/topic"); //구독 요청을 처리할 prefix
+        registry.setApplicationDestinationPrefixes("/app"); //클라이언트가 메시지를 발행할 때 사용할 prefix
+    }
+
+    /**
+     * 웹소켓 엔드포인트 등록 및 모든 오리진에서의 접근 허용
+     *
+     * ex) ws:localhost:9090/chats
+     * @param registry
+     */
+    @Override
+    public void registerStompEndpoints(StompEndpointRegistry registry) {
+        registry.addEndpoint("/chats")
+                .setAllowedOrigins("*")
+                .withSockJS();
+    }
+
+
+    /**
+     * 클라이언트로부터 들어오는 메시지를 처리하는 채널에 인터셉터 등록
+     * @param registration
+     */
+    @Override
+    public void configureClientInboundChannel(ChannelRegistration registration) {
+        registration.interceptors(stompHandler);
     }
 }

--- a/src/main/java/com/my/relink/chat/config/WebSocketConfig.java
+++ b/src/main/java/com/my/relink/chat/config/WebSocketConfig.java
@@ -9,6 +9,7 @@ import org.springframework.messaging.simp.config.MessageBrokerRegistry;
 import org.springframework.web.socket.config.annotation.EnableWebSocketMessageBroker;
 import org.springframework.web.socket.config.annotation.StompEndpointRegistry;
 import org.springframework.web.socket.config.annotation.WebSocketMessageBrokerConfigurer;
+import org.springframework.web.socket.config.annotation.WebSocketTransportRegistration;
 
 @Configuration
 @EnableWebSocketMessageBroker //STOMP 활성화
@@ -28,7 +29,10 @@ public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
         registry.setApplicationDestinationPrefixes("/app"); //클라이언트가 메시지를 발행할 때 사용할 prefix
     }
 
-    /**
+    /**백업 통신 방법 설정
+     *
+     * 웹소켓 연결에 실패했을 시 SockJS가 대체 전송 방식을 사용하며, 이 떄 해당 설정이 적용된다
+     *
      * 웹소켓 엔드포인트 등록 및 모든 오리진에서의 접근 허용
      *
      * ex) ws:localhost:9090/chats
@@ -38,9 +42,27 @@ public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
     public void registerStompEndpoints(StompEndpointRegistry registry) {
         registry.addEndpoint("/chat")
                 .setAllowedOriginPatterns("*")
-                .withSockJS();
+                .withSockJS()
+                .setStreamBytesLimit(512 * 1024) //512kb
+                .setHttpMessageCacheSize(1000) //웹소켓 연결이 끊겼을 시 재연결을 위해 메시지를 캐시하는 개수. 1000개 정도가 일시적 네트워크 문제 시 대부분의 메시지를 복구할 수 있다 함
+                .setDisconnectDelay(30 * 1000); //30초. 클라이언트와의 연결이 끊어졌다고 판단하기까지의 대기 시간
     }
 
+    /**
+     * 주 통신 방법 설정
+     *
+     * 웹소켓 연결 성공시 해당 설정이 적용된다
+     *
+     * @param registry
+     */
+    @Override
+    public void configureWebSocketTransport(WebSocketTransportRegistration registry) {
+        registry
+                .setMessageSizeLimit(512 * 1024)  // 메시지 크기 제한: 512kb
+                .setSendBufferSizeLimit(1024 * 1024)  // 버퍼 크기 제한: 1mb
+                .setSendTimeLimit(20 * 1000)  // 메시지 전송 제한 시간: 20초
+                .setTimeToFirstMessage(30 * 1000);  // 첫 메시지 수신 대기 시간: 30초
+    }
 
     /**
      * 클라이언트로부터 들어오는 메시지를 처리하는 채널에 인터셉터 등록

--- a/src/main/java/com/my/relink/chat/config/WebSocketConfig.java
+++ b/src/main/java/com/my/relink/chat/config/WebSocketConfig.java
@@ -36,7 +36,7 @@ public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
      */
     @Override
     public void registerStompEndpoints(StompEndpointRegistry registry) {
-        registry.addEndpoint("/chats")
+        registry.addEndpoint("/chat")
                 .setAllowedOriginPatterns("*")
                 .withSockJS();
     }

--- a/src/main/java/com/my/relink/chat/config/WebSocketConfig.java
+++ b/src/main/java/com/my/relink/chat/config/WebSocketConfig.java
@@ -2,6 +2,7 @@ package com.my.relink.chat.config;
 
 import com.my.relink.chat.handler.StompHandler;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.messaging.simp.config.ChannelRegistration;
 import org.springframework.messaging.simp.config.MessageBrokerRegistry;
@@ -12,6 +13,7 @@ import org.springframework.web.socket.config.annotation.WebSocketMessageBrokerCo
 @Configuration
 @EnableWebSocketMessageBroker //STOMP 활성화
 @RequiredArgsConstructor
+@Slf4j
 public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
 
     private final StompHandler stompHandler;
@@ -35,7 +37,7 @@ public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
     @Override
     public void registerStompEndpoints(StompEndpointRegistry registry) {
         registry.addEndpoint("/chats")
-                .setAllowedOrigins("*")
+                .setAllowedOriginPatterns("*")
                 .withSockJS();
     }
 
@@ -47,5 +49,6 @@ public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
     @Override
     public void configureClientInboundChannel(ChannelRegistration registration) {
         registration.interceptors(stompHandler);
+        log.debug("stomp handler 인터셉터 등록 완료");
     }
 }

--- a/src/main/java/com/my/relink/chat/controller/ChatController.java
+++ b/src/main/java/com/my/relink/chat/controller/ChatController.java
@@ -1,2 +1,10 @@
-package com.my.relink.chat.controller;public class ChatController {
+package com.my.relink.chat.controller;
+
+import org.springframework.stereotype.Controller;
+
+@Controller
+public class ChatController {
+
+
+
 }

--- a/src/main/java/com/my/relink/chat/controller/ChatController.java
+++ b/src/main/java/com/my/relink/chat/controller/ChatController.java
@@ -1,0 +1,2 @@
+package com.my.relink.chat.controller;public class ChatController {
+}

--- a/src/main/java/com/my/relink/chat/handler/StompHandler.java
+++ b/src/main/java/com/my/relink/chat/handler/StompHandler.java
@@ -1,4 +1,65 @@
 package com.my.relink.chat.handler;
 
-public class StmopHandler {
+import com.my.relink.chat.config.ChatPrincipal;
+import com.my.relink.config.security.AuthUser;
+import com.my.relink.config.security.jwt.JwtProvider;
+import com.my.relink.domain.trade.TradeStatus;
+import com.my.relink.ex.BusinessException;
+import com.my.relink.ex.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.MessageChannel;
+import org.springframework.messaging.simp.stomp.StompCommand;
+import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
+import org.springframework.messaging.support.ChannelInterceptor;
+import org.springframework.messaging.support.MessageHeaderAccessor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class StompHandler implements ChannelInterceptor {
+
+    private final JwtProvider jwtProvider;
+
+
+    /**
+     * 초기 웹소켓 연결 시점에 검증 진행
+     *
+     * 이미 '/chat/{tradeId}' 시점에서 해당 trade에 접근 가능한지 검사하기 때문에
+     * 여기서는 토큰 검증만 진행
+     * @param message
+     * @param channel
+     * @return
+     */
+
+    //TODO jwt 관련 exception 추가되면 에러 catch 추가할 것
+    @Override
+    public Message<?> preSend(Message<?> message, MessageChannel channel) {
+        StompHeaderAccessor accessor = MessageHeaderAccessor.getAccessor(message, StompHeaderAccessor.class);
+
+        if(StompCommand.CONNECT.equals(accessor.getCommand())){
+            //토큰 검증
+            String tokenWithPrefix = accessor.getFirstNativeHeader(WebSocketHeader.AUTH_HEADER);
+            String token = tokenWithPrefix.replace(JwtProvider.TOKEN_PREFIX, "");
+            AuthUser authUser = jwtProvider.getAuthUserForToken(token);
+
+            //TradeStatus 검증: EXCHANGED, CANCELED가 아닐 때만 접근 허용한다
+            validateChatRoomAccess(accessor);
+            accessor.setUser(new ChatPrincipal(authUser));
+        }
+        return message;
+    }
+
+    private void validateChatRoomAccess(StompHeaderAccessor accessor){
+        String tradeStatus = accessor.getFirstNativeHeader(WebSocketHeader.TRADE_STATUS_HEADER);
+
+        if(tradeStatus == null){
+            throw new BusinessException(ErrorCode.TRADE_STATUS_NOT_FOUND);
+        }
+
+        if(TradeStatus.statusOf(tradeStatus) == TradeStatus.CANCELED
+                || TradeStatus.statusOf(tradeStatus) == TradeStatus.EXCHANGED){
+            throw new BusinessException(ErrorCode.CHATROOM_ACCESS_DENIED);
+        }
+    }
 }

--- a/src/main/java/com/my/relink/chat/handler/StompHandler.java
+++ b/src/main/java/com/my/relink/chat/handler/StompHandler.java
@@ -18,6 +18,8 @@ import org.springframework.messaging.support.MessageBuilder;
 import org.springframework.messaging.support.MessageHeaderAccessor;
 import org.springframework.stereotype.Component;
 
+import java.util.List;
+
 @Component
 @RequiredArgsConstructor
 @Slf4j
@@ -65,8 +67,7 @@ public class StompHandler implements ChannelInterceptor {
             throw new BusinessException(ErrorCode.TRADE_STATUS_NOT_FOUND);
         }
 
-        if(TradeStatus.statusOf(tradeStatus) == TradeStatus.CANCELED
-                || TradeStatus.statusOf(tradeStatus) == TradeStatus.EXCHANGED){
+        if(List.of(TradeStatus.CANCELED, TradeStatus.EXCHANGED).contains(TradeStatus.statusOf(tradeStatus))){
             log.debug("더 이상 채팅 세션을 제공하지 않는 거래 채팅방에 접근 시도 - tradeStatus : {}", tradeStatus);
             throw new BusinessException(ErrorCode.CHATROOM_ACCESS_DENIED);
         }

--- a/src/main/java/com/my/relink/chat/handler/StompHandler.java
+++ b/src/main/java/com/my/relink/chat/handler/StompHandler.java
@@ -1,0 +1,4 @@
+package com.my.relink.chat.handler;
+
+public class StmopHandler {
+}

--- a/src/main/java/com/my/relink/chat/handler/StompHandler.java
+++ b/src/main/java/com/my/relink/chat/handler/StompHandler.java
@@ -26,7 +26,7 @@ public class StompHandler implements ChannelInterceptor {
      * 초기 웹소켓 연결 시점에 검증 진행
      *
      * 이미 '/chat/{tradeId}' 시점에서 해당 trade에 접근 가능한지 검사하기 때문에
-     * 여기서는 토큰 검증만 진행
+     * 여기서는 토큰과 채팅 세션 연결 검증만 수행한다
      * @param message
      * @param channel
      * @return

--- a/src/main/java/com/my/relink/chat/handler/WebSocketHeader.java
+++ b/src/main/java/com/my/relink/chat/handler/WebSocketHeader.java
@@ -1,2 +1,6 @@
-package com.my.relink.chat.handler;public interface WebSocketHeader {
+package com.my.relink.chat.handler;
+
+public interface WebSocketHeader {
+    public final String AUTH_HEADER = "Authorization";
+    public final String TRADE_STATUS_HEADER = "TradeStatus";
 }

--- a/src/main/java/com/my/relink/chat/handler/WebSocketHeader.java
+++ b/src/main/java/com/my/relink/chat/handler/WebSocketHeader.java
@@ -1,0 +1,2 @@
+package com.my.relink.chat.handler;public interface WebSocketHeader {
+}

--- a/src/main/java/com/my/relink/chat/handler/WebSocketHeader.java
+++ b/src/main/java/com/my/relink/chat/handler/WebSocketHeader.java
@@ -1,6 +1,6 @@
 package com.my.relink.chat.handler;
 
 public interface WebSocketHeader {
-    public final String AUTH_HEADER = "Authorization";
-    public final String TRADE_STATUS_HEADER = "TradeStatus";
+    String AUTH_HEADER = "Authorization";
+    String TRADE_STATUS_HEADER = "TradeStatus";
 }

--- a/src/main/java/com/my/relink/config/security/JwtAuthorizationFilter.java
+++ b/src/main/java/com/my/relink/config/security/JwtAuthorizationFilter.java
@@ -20,7 +20,7 @@ public class JwtAuthorizationFilter extends OncePerRequestFilter {
 
     @Override
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
-        if (request.getRequestURI().contains("/auth")) {
+        if (request.getRequestURI().contains("/auth") || isWsEndPoint(request)) {
             filterChain.doFilter(request, response);
             return;
         }
@@ -37,5 +37,8 @@ public class JwtAuthorizationFilter extends OncePerRequestFilter {
         LoginAuthentication loginAuthentication = new LoginAuthentication(authUser);
         SecurityContextHolder.getContext().setAuthentication(loginAuthentication);
         filterChain.doFilter(request, response);
+    }
+    private boolean isWsEndPoint(HttpServletRequest request){
+        return request.getRequestURI().contains("/chats");
     }
 }

--- a/src/main/java/com/my/relink/config/security/JwtAuthorizationFilter.java
+++ b/src/main/java/com/my/relink/config/security/JwtAuthorizationFilter.java
@@ -39,6 +39,6 @@ public class JwtAuthorizationFilter extends OncePerRequestFilter {
         filterChain.doFilter(request, response);
     }
     private boolean isWsEndPoint(HttpServletRequest request){
-        return request.getRequestURI().contains("/chats");
+        return request.getRequestURI().contains("/chat");
     }
 }

--- a/src/main/java/com/my/relink/config/security/config/SecurityConfig.java
+++ b/src/main/java/com/my/relink/config/security/config/SecurityConfig.java
@@ -51,7 +51,7 @@ public class SecurityConfig {
                 .authorizeHttpRequests(auth -> {
                     auth
                             .dispatcherTypeMatchers(DispatcherType.FORWARD, DispatcherType.ERROR).permitAll()
-                            .requestMatchers("/auth/**").permitAll()
+                            .requestMatchers("/auth/**", "/chats/**").permitAll()
                             .requestMatchers("/error").permitAll();
                     if (profileType.equals("dev")) {
                         auth.requestMatchers(PathRequest.toH2Console()).permitAll();

--- a/src/main/java/com/my/relink/config/security/config/SecurityConfig.java
+++ b/src/main/java/com/my/relink/config/security/config/SecurityConfig.java
@@ -51,7 +51,7 @@ public class SecurityConfig {
                 .authorizeHttpRequests(auth -> {
                     auth
                             .dispatcherTypeMatchers(DispatcherType.FORWARD, DispatcherType.ERROR).permitAll()
-                            .requestMatchers("/auth/**", "/chats/**").permitAll()
+                            .requestMatchers("/auth/**", "/chat/**").permitAll()
                             .requestMatchers("/error").permitAll();
                     if (profileType.equals("dev")) {
                         auth.requestMatchers(PathRequest.toH2Console()).permitAll();

--- a/src/main/java/com/my/relink/controller/user/dto/req/AddressCreateReqDto.java
+++ b/src/main/java/com/my/relink/controller/user/dto/req/AddressCreateReqDto.java
@@ -8,10 +8,12 @@ import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import org.hibernate.validator.constraints.Length;
 
 @Getter
 @AllArgsConstructor
+@NoArgsConstructor
 public class AddressCreateReqDto {
 
     @NotNull(message = "우편번호를 적어주세요.")

--- a/src/main/java/com/my/relink/controller/user/dto/req/UserCreateReqDto.java
+++ b/src/main/java/com/my/relink/controller/user/dto/req/UserCreateReqDto.java
@@ -8,9 +8,11 @@ import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Pattern;
 import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import org.hibernate.validator.constraints.Length;
 
 @Getter
+@NoArgsConstructor
 public class UserCreateReqDto {
 
     @NotBlank(message = "이름을 적어주세요.")

--- a/src/main/java/com/my/relink/domain/trade/TradeStatus.java
+++ b/src/main/java/com/my/relink/domain/trade/TradeStatus.java
@@ -1,6 +1,10 @@
 package com.my.relink.domain.trade;
 
+import com.my.relink.ex.BusinessException;
+import com.my.relink.ex.ErrorCode;
 import lombok.Getter;
+
+import java.util.Arrays;
 
 @Getter
 public enum TradeStatus {
@@ -17,5 +21,12 @@ public enum TradeStatus {
 
     TradeStatus(String message) {
         this.message = message;
+    }
+
+    public static TradeStatus statusOf(String message){
+        return Arrays.stream(values())
+                .filter(tradeStatus -> tradeStatus.getMessage().equals(message))
+                .findFirst()
+                .orElseThrow(() -> new BusinessException(ErrorCode.TRADE_STATUS_NOT_FOUND));
     }
 }

--- a/src/main/java/com/my/relink/ex/ErrorCode.java
+++ b/src/main/java/com/my/relink/ex/ErrorCode.java
@@ -20,6 +20,8 @@ public enum ErrorCode {
     POINT_NOT_FOUND(HttpStatus.NOT_FOUND.value(), "포인트를 찾을 수 없습니다"),
     POINT_SHORTAGE(HttpStatus.FORBIDDEN.value(), "포인트가 부족합니다"),
     POINT_HISTORY_NOT_FOUND(HttpStatus.NOT_FOUND.value(), "포인트 내역을 찾을 수 없습니다"),
+    CHATROOM_ACCESS_DENIED(HttpStatus.FORBIDDEN.value(), "거래가 완료되었거나 취소된 채팅방에는 접근할 수 없습니다"),
+    TRADE_STATUS_NOT_FOUND(HttpStatus.NOT_FOUND.value(), "존재하지 않는 거래 상태 입니다")
 
 
 

--- a/src/main/resources/application-dev.yaml
+++ b/src/main/resources/application-dev.yaml
@@ -30,6 +30,8 @@ logging:
   level:
     org.hibernate.orm.jdbc.bind: TRACE
     com.my.relink: DEBUG
+    org.springframework.web.socket: DEBUG
+    org.springframework.messaging: DEBUG
 
 jwt:
   secret:

--- a/src/main/resources/application-dev.yaml
+++ b/src/main/resources/application-dev.yaml
@@ -1,0 +1,36 @@
+server:
+  port: 9090
+  servlet:
+    encoding:
+      charset: utf-8
+      force: true
+spring:
+  datasource:
+    url: jdbc:h2:mem:test;MODE=MySQL
+    driver-class-name: org.h2.Driver
+    username: sa
+    password:
+  h2:
+    console:
+      enabled: true
+  jpa:
+    open-in-view: false
+    hibernate:
+      ddl-auto: update
+    properties:
+      '[hibernate.default_batch_fetch_size]': 100
+      '[hibernate.format_sql]': true
+    show-sql: true
+  output:
+    ansi:
+      enabled: always
+
+
+logging:
+  level:
+    org.hibernate.orm.jdbc.bind: TRACE
+    com.my.relink: DEBUG
+
+jwt:
+  secret:
+    key: XyZ1a2b3c4d5e6f7g8h9i0j1k2l3m4n5o6p7q8r9s0t1u2v3w4x5y6z7A8B9C0D1

--- a/src/test/java/com/my/relink/chat/handler/StompHandlerTest.java
+++ b/src/test/java/com/my/relink/chat/handler/StompHandlerTest.java
@@ -1,4 +1,161 @@
+package com.my.relink.chat.handler;
+
+import com.my.relink.config.security.AuthUser;
+import com.my.relink.config.security.jwt.JwtProvider;
+import com.my.relink.domain.user.Role;
+import com.my.relink.domain.user.User;
+import com.my.relink.ex.BusinessException;
+import com.my.relink.ex.ErrorCode;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.messaging.MessageDeliveryException;
+import org.springframework.messaging.converter.MappingJackson2MessageConverter;
+import org.springframework.messaging.simp.stomp.ConnectionLostException;
+import org.springframework.messaging.simp.stomp.StompHeaders;
+import org.springframework.messaging.simp.stomp.StompSession;
+import org.springframework.messaging.simp.stomp.StompSessionHandlerAdapter;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.web.socket.WebSocketHttpHeaders;
+import org.springframework.web.socket.client.WebSocketClient;
+import org.springframework.web.socket.client.standard.StandardWebSocketClient;
+import org.springframework.web.socket.messaging.WebSocketStompClient;
+import org.springframework.web.socket.sockjs.client.SockJsClient;
+import org.springframework.web.socket.sockjs.client.WebSocketTransport;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+
 import static org.junit.jupiter.api.Assertions.*;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 class StompHandlerTest {
-  
+    @LocalServerPort
+    private int port;
+
+    @Autowired
+    private JwtProvider jwtProvider;
+
+
+    private WebSocketStompClient stompClient;
+    private String websocketUrl;
+
+    @BeforeEach
+    void setUp() {
+        websocketUrl = "http://localhost:" + port + "/chats";
+        WebSocketClient webSocketClient = new SockJsClient(
+                Collections.singletonList(new WebSocketTransport(new StandardWebSocketClient()))
+        );
+        stompClient = new WebSocketStompClient(webSocketClient);
+        stompClient.setMessageConverter(new MappingJackson2MessageConverter());
+    }
+
+    @Test
+    @DisplayName("유효한 토큰과 진행중인 거래상태로 연결 시도시 성공한다")
+    void preSend_connectWithValidToken_andActiveTradeStatus() throws Exception {
+
+        String token = createValidToken();
+        StompHeaders headers = createStompHeaders(token, "교환 가능");
+
+        StompSession session = stompClient
+                .connectAsync(websocketUrl, new WebSocketHttpHeaders(), headers, new StompSessionHandlerAdapter() {})
+                .get(1, TimeUnit.SECONDS);
+
+
+        assertTrue(session.isConnected());
+
+        session.disconnect();
+    }
+
+
+    @Test
+    @DisplayName("완료된 거래의 채팅방 접근시 에러가 발생한다")
+    void preSend_connectWithCompletedTradeStatus_throwsException() {
+        String token = createValidToken();
+        StompHeaders headers = createStompHeaders(token, "교환 완료");
+
+        ExecutionException exception = assertThrows(ExecutionException.class, () -> {
+            stompClient
+                    .connectAsync(websocketUrl, new WebSocketHttpHeaders(), headers, new StompSessionHandlerAdapter() {
+                        @Override
+                        public void handleTransportError(StompSession session, Throwable exception) {
+                            if (exception.getCause() instanceof MessageDeliveryException) {
+                                MessageDeliveryException ex = (MessageDeliveryException) exception.getCause();
+                                assertEquals(ErrorCode.TRADE_ACCESS_DENIED.getMessage(), ex.getMessage());
+                            }
+                        }
+                    })
+                    .get(3, TimeUnit.SECONDS);
+        });
+
+        Throwable cause = exception.getCause();
+
+        assertTrue(cause instanceof ConnectionLostException);
+    }
+
+    @Test
+    @DisplayName("취소된 거래의 채팅방 접근시 에러가 발생한다")
+    void preSend_connectWithCanceledTradeStatus_throwsException() {
+        String token = createValidToken();
+        StompHeaders headers = createStompHeaders(token, "교환 취소");
+
+        ExecutionException exception = assertThrows(ExecutionException.class, () -> {
+            stompClient
+                    .connectAsync(websocketUrl, new WebSocketHttpHeaders(), headers, new StompSessionHandlerAdapter() {
+                        @Override
+                        public void handleTransportError(StompSession session, Throwable exception) {
+                            if (exception.getCause() instanceof MessageDeliveryException) {
+                                MessageDeliveryException ex = (MessageDeliveryException) exception.getCause();
+                                assertEquals(ErrorCode.TRADE_ACCESS_DENIED.getMessage(), ex.getMessage());
+                            }
+                        }
+                    })
+                    .get(3, TimeUnit.SECONDS);
+        });
+
+        Throwable cause = exception.getCause();
+
+        assertTrue(cause instanceof ConnectionLostException);
+    }
+
+
+    private StompHeaders createStompHeaders(String token, String tradeStatus) {
+        StompHeaders headers = new StompHeaders();
+        headers.add(WebSocketHeader.AUTH_HEADER, token);
+        headers.add(WebSocketHeader.TRADE_STATUS_HEADER, tradeStatus);
+        return headers;
+    }
+
+    private String createValidToken() {
+        User user = User.builder()
+                .email("riku1234@naver.com")
+                .id(1L)
+                .role(Role.USER)
+                .build();
+
+        AuthUser authUser = AuthUser.from(user);
+
+        List<GrantedAuthority> authorities = Collections.singletonList(
+                new SimpleGrantedAuthority("ROLE_" + Role.USER.name())
+        );
+
+        Authentication authentication = new UsernamePasswordAuthenticationToken(
+                authUser,
+                null,
+                authorities
+        );
+
+        return jwtProvider.generateToken(authentication);
+    }
+
+
 }

--- a/src/test/java/com/my/relink/chat/handler/StompHandlerTest.java
+++ b/src/test/java/com/my/relink/chat/handler/StompHandlerTest.java
@@ -1,0 +1,4 @@
+import static org.junit.jupiter.api.Assertions.*;
+class StompHandlerTest {
+  
+}


### PR DESCRIPTION
## 💫 PR 개요
적합한 TradeStatus를 갖는 거래에 참여 중인 인증된 유저의 경우에만 웹소켓 커넥션을 허용한다

* 적합한 TradeStatus: 교환 가능, 교환 중, 배송 중

## 📌 관련 이슈
<!-- 이슈 연결 -->
- Open #35

## 🛠 작업 내용
* endpoint: http://localhost:9090/chats
** 필수 헤더
  - `Authorization`: JWT
  - `TradeStatus`: 거래 상태

이미 /chat/{tradeId}에서 해당 Trade에 속한 유저인지 검증하기 때문에
여기선 유저 인증과 TradeStatus가 교환 취소/교환 완료가 아닌지를 검증한 후 커넥션 연결을 허용합니다

1. 토큰 검증 수행 -> (추후 jwt 에러 쪽 구현이 완료되면 해당 처리 추가할 예정입니다)
2. TradeStatus가 '교환 완료'/'교환 취소'인지 검증한다 -> 해당된다면 에러 throw

### 웹소켓 설정
STOMP 기반으로 웹소켓 설정을 진행했습니다
1. 메시지 브로커 구성
- 구독 요청 처리 prefix: /topic
- 클라이언트 메시지 발행 prefix: /app
- STOMP 핸들러 인터셉터 추가
2. 웹소켓 엔드포인트: /chats
- SockJS 지원 추가
  - 웹소켓을 지원하지 않는 오래된 환경에서도 실시간 통신 가능
  - 일부 프록시/방화벽이 웹소켓 연결을 차단하는 경우에도 통신 가능

### STOMP 핸들러 인터셉터
현재는 웹소켓 연결 시점의 보안 검증을 처리하는 기능을 추가했습니다

1. 사용자 인증
CONNECT 커맨드 시점에 토큰 검증 후 사용자 정보를 WebSocket 세션에 바인딩

2. 채팅방 접근 검증
TradeStatus가 교환 완료 또는 교환 취소인 상태는 커넥션 획득 차단

3. 예외 처리
MessageDeliveryException를 던지며 해당 메시지를 담은 에러 응답을 반환합니다
***예외 처리는 전체적으로 계속 보강하며 구성할 예정입니다(공부하며...)

### 테스트

https://jiangxy.github.io/websocket-debug-tool/
위 사이트에서 테스트 가능합니다!

- 유효한 토큰과 진행중인 거래상태로 연결 시도 시 성공하는 케이스
- 교환 완료 상태일 시 커넥션 요청 시 에러 던지는 케이스
- 교환 취소 상태일 시 커넥션 요청 시 에러 던지는 케이스

## 리뷰 요청 사항
추가된 웹소켓 설정 구성들

## 체크리스트
<!-- PR을 생성하기 전에 확인해야 할 사항들 -->
- [x] 코드 컨벤션을 준수하였습니다
- [x] 커밋 메시지를 컨벤션에 맞게 작성하였습니다
- [x] conflict가 모두 해결되었습니다
- [x] 테스트 코드를 작성하였습니다
- [x] self review를 진행하였습니다