### PR TITLE
Feat: 교환 진행 페이지 - 운송장 번호 입력 받기

### DIFF
--- a/src/main/java/com/my/relink/controller/trade/TradeController.java
+++ b/src/main/java/com/my/relink/controller/trade/TradeController.java
@@ -67,7 +67,7 @@ public class TradeController {
             @PathVariable(name = "tradeId") Long tradeId,
             @Valid @RequestBody TrackingNumberReqDto reqDto,
             @AuthenticationPrincipal AuthUser authUser) {
-        tradeService.getTrackingNumber(tradeId, reqDto, authUser);
+        tradeService.getExchangeItemTrackingNumber(tradeId, reqDto, authUser);
         return ResponseEntity.noContent().build();
     }
 

--- a/src/main/java/com/my/relink/controller/trade/TradeController.java
+++ b/src/main/java/com/my/relink/controller/trade/TradeController.java
@@ -2,10 +2,10 @@ package com.my.relink.controller.trade;
 
 import com.my.relink.config.security.AuthUser;
 import com.my.relink.controller.trade.dto.request.AddressReqDto;
+import com.my.relink.controller.trade.dto.request.TrackingNumberReqDto;
 import com.my.relink.controller.trade.dto.response.AddressRespDto;
 import com.my.relink.controller.trade.dto.response.TradeCompleteRespDto;
 import com.my.relink.controller.trade.dto.response.TradeInquiryDetailRespDto;
-import com.my.relink.controller.trade.dto.request.TradeReqDto;
 import com.my.relink.controller.trade.dto.response.TradeRequestRespDto;
 import com.my.relink.service.TradeService;
 import com.my.relink.util.api.ApiResult;
@@ -21,15 +21,12 @@ public class TradeController {
 
     private final TradeService tradeService;
 
-
-
     @GetMapping("/chat/{tradeId}")
     public ResponseEntity<ApiResult<TradeInquiryDetailRespDto>> getTradeInquiryChatRoom(
             @PathVariable("tradeId") Long tradeId,
-            @AuthenticationPrincipal AuthUser authUser){
+            @AuthenticationPrincipal AuthUser authUser) {
         return ResponseEntity.ok(ApiResult.success(tradeService.getTradeInquiryDetail(tradeId, authUser.getId())));
     }
-
 
     @PostMapping("/trades/{tradeId}/request")
     public ResponseEntity<ApiResult<TradeRequestRespDto>> requestTrade(
@@ -40,7 +37,7 @@ public class TradeController {
     }
 
     @PostMapping("/trades/{tradeId}/request-cancel")
-    public ResponseEntity<Void> cancelTradeRequest(
+    public ResponseEntity<ApiResult<Void>> cancelTradeRequest(
             @PathVariable(name = "tradeId") Long tradeId,
             @AuthenticationPrincipal AuthUser authUser) {
         tradeService.cancelTradeRequest(tradeId, authUser);
@@ -51,7 +48,7 @@ public class TradeController {
     public ResponseEntity<ApiResult<AddressRespDto>> createAddress(
             @PathVariable(name = "tradeId") Long tradeId,
             @RequestBody AddressReqDto reqDto,
-            @AuthenticationPrincipal AuthUser authUser){
+            @AuthenticationPrincipal AuthUser authUser) {
         AddressRespDto responseDto = tradeService.createAddress(tradeId, reqDto, authUser);
         return new ResponseEntity<>(ApiResult.success(responseDto), HttpStatus.CREATED);
     }
@@ -59,9 +56,18 @@ public class TradeController {
     @PostMapping("/trades/{tradeId}/completion/received")
     public ResponseEntity<ApiResult<TradeCompleteRespDto>> completeTrade(
             @PathVariable(name = "tradeId") Long tradeId,
-            @AuthenticationPrincipal AuthUser authUser){
+            @AuthenticationPrincipal AuthUser authUser) {
         TradeCompleteRespDto responseDto = tradeService.completeTrade(tradeId, authUser);
         return new ResponseEntity<>(ApiResult.success(responseDto), HttpStatus.OK);
+    }
+
+    @PostMapping("/trades/{tradeId}/tracking-number")
+    public ResponseEntity<ApiResult<Void>> getTrackingNumber(
+            @PathVariable(name = "tradeId") Long tradeId,
+            @RequestBody TrackingNumberReqDto reqDto,
+            @AuthenticationPrincipal AuthUser authUser) {
+        tradeService.getTrackingNumber(tradeId, reqDto, authUser);
+        return ResponseEntity.noContent().build();
     }
 
 }

--- a/src/main/java/com/my/relink/controller/trade/TradeController.java
+++ b/src/main/java/com/my/relink/controller/trade/TradeController.java
@@ -9,6 +9,7 @@ import com.my.relink.controller.trade.dto.response.TradeInquiryDetailRespDto;
 import com.my.relink.controller.trade.dto.response.TradeRequestRespDto;
 import com.my.relink.service.TradeService;
 import com.my.relink.util.api.ApiResult;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -64,7 +65,7 @@ public class TradeController {
     @PostMapping("/trades/{tradeId}/tracking-number")
     public ResponseEntity<ApiResult<Void>> getTrackingNumber(
             @PathVariable(name = "tradeId") Long tradeId,
-            @RequestBody TrackingNumberReqDto reqDto,
+            @Valid @RequestBody TrackingNumberReqDto reqDto,
             @AuthenticationPrincipal AuthUser authUser) {
         tradeService.getTrackingNumber(tradeId, reqDto, authUser);
         return ResponseEntity.noContent().build();

--- a/src/main/java/com/my/relink/controller/trade/dto/request/TrackingNumberReqDto.java
+++ b/src/main/java/com/my/relink/controller/trade/dto/request/TrackingNumberReqDto.java
@@ -1,0 +1,10 @@
+package com.my.relink.controller.trade.dto.request;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class TrackingNumberReqDto {
+    private String trackingNumber;
+}

--- a/src/main/java/com/my/relink/controller/trade/dto/request/TrackingNumberReqDto.java
+++ b/src/main/java/com/my/relink/controller/trade/dto/request/TrackingNumberReqDto.java
@@ -1,10 +1,13 @@
 package com.my.relink.controller.trade.dto.request;
 
+import jakarta.validation.constraints.NotBlank;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
+import org.springframework.validation.annotation.Validated;
 
 @Getter
 @AllArgsConstructor
 public class TrackingNumberReqDto {
+    @NotBlank(message = "운송장 번호는 필수 입력 값입니다.")
     private String trackingNumber;
 }

--- a/src/main/java/com/my/relink/domain/trade/Trade.java
+++ b/src/main/java/com/my/relink/domain/trade/Trade.java
@@ -1,5 +1,6 @@
 package com.my.relink.domain.trade;
 
+import com.my.relink.controller.trade.dto.request.TrackingNumberReqDto;
 import com.my.relink.domain.BaseEntity;
 import com.my.relink.domain.item.exchange.ExchangeItem;
 import com.my.relink.domain.user.Address;
@@ -115,5 +116,13 @@ public class Trade extends BaseEntity {
 
     public void saveRequesterAddress(Address newAddress) {
         this.requesterAddress = newAddress;
+    }
+
+    public void updateRequesterTrackingNumber(String requesterTrackingNumber) {
+        this.requesterTrackingNumber = requesterTrackingNumber;
+    }
+
+    public void updateOwnerTrackingNumber(String ownerTrackingNumber) {
+        this.ownerTrackingNumber = ownerTrackingNumber;
     }
 }

--- a/src/main/java/com/my/relink/domain/trade/Trade.java
+++ b/src/main/java/com/my/relink/domain/trade/Trade.java
@@ -125,6 +125,10 @@ public class Trade extends BaseEntity {
         this.ownerTrackingNumber = ownerTrackingNumber;
     }
 
+    public boolean isRequester(Long userId) {
+        return this.requester.getId().equals(userId);
+    }
+
     @Builder
     public Trade(
             Long id,

--- a/src/main/java/com/my/relink/service/PointTransactionService.java
+++ b/src/main/java/com/my/relink/service/PointTransactionService.java
@@ -48,6 +48,7 @@ public class PointTransactionService {
         pointHistoryRepository.save(restorePointHistory);
     }
 
+    @Transactional
     public void deductPoints(Long tradeId, User currentUser) {
         //해당 로그인 유저의 포인트를 조회
         Point point = pointRepository.findByUserId(currentUser.getId())

--- a/src/main/java/com/my/relink/service/TradeService.java
+++ b/src/main/java/com/my/relink/service/TradeService.java
@@ -163,7 +163,7 @@ public class TradeService {
     }
 
     @Transactional
-    public void getTrackingNumber(Long tradeId, TrackingNumberReqDto reqDto, AuthUser authUser) {
+    public void getExchangeItemTrackingNumber(Long tradeId, TrackingNumberReqDto reqDto, AuthUser authUser) {
         User currentUser = userRepository.findById(authUser.getId())
                 .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
 

--- a/src/main/java/com/my/relink/service/TradeService.java
+++ b/src/main/java/com/my/relink/service/TradeService.java
@@ -176,7 +176,7 @@ public class TradeService {
             trade.updateOwnerTrackingNumber(reqDto.getTrackingNumber());
         }
 
-        if(!trade.getOwnerTrackingNumber().isEmpty() && !trade.getRequesterTrackingNumber().isEmpty()){
+        if (!trade.getOwnerTrackingNumber().isEmpty() && !trade.getRequesterTrackingNumber().isEmpty()) {
             trade.updateTradeStatus(TradeStatus.IN_DELIVERY);
         }
         tradeRepository.save(trade);

--- a/src/main/java/com/my/relink/service/TradeService.java
+++ b/src/main/java/com/my/relink/service/TradeService.java
@@ -175,6 +175,10 @@ public class TradeService {
         } else {
             trade.updateOwnerTrackingNumber(reqDto.getTrackingNumber());
         }
+
+        if(!trade.getOwnerTrackingNumber().isEmpty() && !trade.getRequesterTrackingNumber().isEmpty()){
+            trade.updateTradeStatus(TradeStatus.IN_DELIVERY);
+        }
         tradeRepository.save(trade);
     }
 }

--- a/src/main/java/com/my/relink/service/TradeService.java
+++ b/src/main/java/com/my/relink/service/TradeService.java
@@ -70,7 +70,7 @@ public class TradeService {
         pointTransactionService.deductPoints(tradeId, currentUser);
 
         //요청자/소유자 여부에 따라 적절한 요청 상태 필드 업데이트
-        if (trade.getRequester().getId().equals(currentUser.getId())) {
+        if (trade.isRequester(currentUser.getId())) {
             trade.updateHasRequesterRequested(true);
         } else {
             trade.updateHasOwnerRequested(true);
@@ -97,7 +97,7 @@ public class TradeService {
         pointTransactionService.restorePoints(tradeId, currentUser);
 
         // 요청 상태 업데이트
-        if (trade.getRequester().getId().equals(currentUser.getId())) {
+        if (trade.isRequester(currentUser.getId())) {
             trade.updateHasRequesterRequested(false);
         } else {
             trade.updateHasOwnerRequested(false);
@@ -120,7 +120,7 @@ public class TradeService {
 
         if (trade.getHasOwnerRequested() && trade.getHasRequesterRequested()) {
             // 소유자 주소와 요청자 주소 업데이트
-            if (trade.getRequester().getId().equals(currentUser.getId())) {
+            if (trade.isRequester(currentUser.getId())) {
                 Address requesterAddress = reqDto.toRequesterAddressEntity();  // 요청자 주소 생성
                 trade.saveRequesterAddress(requesterAddress);
             } else {
@@ -144,7 +144,7 @@ public class TradeService {
                 .orElseThrow(() -> new BusinessException(ErrorCode.TRADE_NOT_FOUND));
 
         //요청자/소유자 여부에 따라 수령상태 변경
-        if (trade.getRequester().getId().equals(currentUser.getId())) {
+        if (trade.isRequester(currentUser.getId())) {
             trade.updateHasRequesterReceived(true);
         } else {
             trade.updateHasOwnerReceived(true);
@@ -170,7 +170,7 @@ public class TradeService {
         Trade trade = tradeRepository.findById(tradeId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.TRADE_NOT_FOUND));
 
-        if (trade.getRequester().getId().equals(currentUser.getId())) {
+        if (trade.isRequester(currentUser.getId())) {
             trade.updateRequesterTrackingNumber(reqDto.getTrackingNumber());
         } else {
             trade.updateOwnerTrackingNumber(reqDto.getTrackingNumber());

--- a/src/main/java/com/my/relink/service/TradeService.java
+++ b/src/main/java/com/my/relink/service/TradeService.java
@@ -2,12 +2,11 @@ package com.my.relink.service;
 
 import com.my.relink.config.security.AuthUser;
 import com.my.relink.controller.trade.dto.request.AddressReqDto;
+import com.my.relink.controller.trade.dto.request.TrackingNumberReqDto;
 import com.my.relink.controller.trade.dto.response.AddressRespDto;
 import com.my.relink.controller.trade.dto.response.TradeCompleteRespDto;
 import com.my.relink.controller.trade.dto.response.TradeInquiryDetailRespDto;
 import com.my.relink.controller.trade.dto.response.TradeRequestRespDto;
-import com.my.relink.domain.point.pointHistory.repository.PointHistoryRepository;
-import com.my.relink.domain.point.repository.PointRepository;
 import com.my.relink.domain.trade.Trade;
 import com.my.relink.domain.trade.TradeStatus;
 import com.my.relink.domain.trade.repository.TradeRepository;
@@ -30,8 +29,6 @@ public class TradeService {
     private final ImageService imageService;
     private final UserRepository userRepository;
     private final PointTransactionService pointTransactionService;
-    private final PointHistoryRepository pointHistoryRepository;
-    private final PointRepository pointRepository;
 
     /**
      * [문의하기] -> 해당 채팅방의 거래 정보, 상품 정보, 상대 유저 정보 내리기
@@ -73,13 +70,13 @@ public class TradeService {
         pointTransactionService.deductPoints(tradeId, currentUser);
 
         //요청자/소유자 여부에 따라 적절한 요청 상태 필드 업데이트
-        if(trade.getRequester().getId().equals(currentUser.getId())){
+        if (trade.getRequester().getId().equals(currentUser.getId())) {
             trade.updateHasRequesterRequested(true);
-        } else{
+        } else {
             trade.updateHasOwnerRequested(true);
         }
         // 양쪽 모두 requested가 true라면 거래 상태를 in_exchange로 변경
-        if(trade.getHasRequesterRequested()&&trade.getHasOwnerRequested()){
+        if (trade.getHasRequesterRequested() && trade.getHasOwnerRequested()) {
             trade.updateTradeStatus(TradeStatus.IN_EXCHANGE);
             tradeRepository.save(trade);
         }
@@ -121,12 +118,12 @@ public class TradeService {
         Trade trade = tradeRepository.findById(tradeId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.TRADE_NOT_FOUND));
 
-        if(trade.getHasOwnerRequested()&&trade.getHasRequesterRequested()){
+        if (trade.getHasOwnerRequested() && trade.getHasRequesterRequested()) {
             // 소유자 주소와 요청자 주소 업데이트
-            if(trade.getRequester().getId().equals(currentUser.getId())){
+            if (trade.getRequester().getId().equals(currentUser.getId())) {
                 Address requesterAddress = reqDto.toRequesterAddressEntity();  // 요청자 주소 생성
                 trade.saveRequesterAddress(requesterAddress);
-            } else{
+            } else {
                 Address ownerAddress = reqDto.toOwnerAddressEntity();  // 소유자 주소 생성
                 trade.saveOwnerAddress(ownerAddress);
             }
@@ -147,21 +144,38 @@ public class TradeService {
                 .orElseThrow(() -> new BusinessException(ErrorCode.TRADE_NOT_FOUND));
 
         //요청자/소유자 여부에 따라 수령상태 변경
-        if(trade.getRequester().getId().equals(currentUser.getId())){
+        if (trade.getRequester().getId().equals(currentUser.getId())) {
             trade.updateHasRequesterReceived(true);
-        } else{
+        } else {
             trade.updateHasOwnerReceived(true);
         }
 
         //양쪽 모두 수령 확인 시 거래 상태 변경
-        if(trade.getHasOwnerReceived() && trade.getHasRequesterReceived()){
+        if (trade.getHasOwnerReceived() && trade.getHasRequesterReceived()) {
             trade.updateTradeStatus(TradeStatus.EXCHANGED);
         }
         //보증금 반환
         Integer amount = trade.getOwnerExchangeItem().getDeposit();
         pointTransactionService.restorePointsForAllTraders(trade, amount);
+        tradeRepository.save(trade);
 
         return new TradeCompleteRespDto(tradeId);
+    }
+
+    @Transactional
+    public void getTrackingNumber(Long tradeId, TrackingNumberReqDto reqDto, AuthUser authUser) {
+        User currentUser = userRepository.findById(authUser.getId())
+                .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
+
+        Trade trade = tradeRepository.findById(tradeId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.TRADE_NOT_FOUND));
+
+        if (trade.getRequester().getId().equals(currentUser.getId())) {
+            trade.updateRequesterTrackingNumber(reqDto.getTrackingNumber());
+        } else {
+            trade.updateOwnerTrackingNumber(reqDto.getTrackingNumber());
+        }
+        tradeRepository.save(trade);
     }
 }
 

--- a/src/main/java/com/my/relink/service/UserService.java
+++ b/src/main/java/com/my/relink/service/UserService.java
@@ -25,7 +25,6 @@ public class UserService {
     private final PointRepository pointRepository;
 
 
-
     public UserCreateRespDto register(UserCreateReqDto dto) {
         dto.changePassword(passwordEncoder.encode(dto.getPassword()));
         User savedUser = userRepository.save(dto.toEntity(dto));

--- a/src/main/java/com/my/relink/service/UserService.java
+++ b/src/main/java/com/my/relink/service/UserService.java
@@ -5,7 +5,6 @@ import com.my.relink.controller.user.dto.resp.*;
 import com.my.relink.domain.image.EntityType;
 import com.my.relink.domain.image.Image;
 import com.my.relink.domain.image.ImageRepository;
-import com.my.relink.domain.review.ReviewRepository;
 import com.my.relink.domain.point.Point;
 import com.my.relink.domain.point.repository.PointRepository;
 import com.my.relink.domain.user.User;

--- a/src/test/java/com/my/relink/service/TradeServiceTest.java
+++ b/src/test/java/com/my/relink/service/TradeServiceTest.java
@@ -19,6 +19,7 @@ import com.my.relink.domain.user.repository.UserRepository;
 import com.my.relink.ex.BusinessException;
 import com.my.relink.ex.ErrorCode;
 import com.my.relink.util.DummyObject;
+import jakarta.validation.ConstraintViolationException;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -261,5 +262,17 @@ class TradeServiceTest extends DummyObject {
         assertEquals("OWN123456", trade.getOwnerTrackingNumber());
         assertEquals(TradeStatus.IN_DELIVERY, trade.getTradeStatus());
         verify(tradeRepository, times(1)).save(trade);
+    }
+
+    @Test
+    @DisplayName("교환 진행 페이지 : 운송장 입력받기 실패 케이스")
+    void testGetTrackingNumber_InvalidTrackingNumber() {
+        // Given
+        Long tradeId = 1L;
+        TrackingNumberReqDto reqDto = new TrackingNumberReqDto(""); // 빈 운송장 번호
+
+        // When & Then
+        assertThrows(BusinessException.class, () ->
+                tradeService.getTrackingNumber(tradeId, reqDto, new AuthUser(12L,"test@email.com", Role.USER)));
     }
 }

--- a/src/test/java/com/my/relink/service/TradeServiceTest.java
+++ b/src/test/java/com/my/relink/service/TradeServiceTest.java
@@ -255,7 +255,7 @@ class TradeServiceTest extends DummyObject {
         when(tradeRepository.findById(tradeId)).thenReturn(Optional.of(trade));
 
         // When
-        tradeService.getTrackingNumber(tradeId, reqDto, new AuthUser(requester.getId(), "test@email.com", Role.USER));
+        tradeService.getExchangeItemTrackingNumber(tradeId, reqDto, new AuthUser(requester.getId(), "test@email.com", Role.USER));
 
         // Then
         assertEquals("REQ123456", trade.getRequesterTrackingNumber());
@@ -273,6 +273,6 @@ class TradeServiceTest extends DummyObject {
 
         // When & Then
         assertThrows(BusinessException.class, () ->
-                tradeService.getTrackingNumber(tradeId, reqDto, new AuthUser(12L,"test@email.com", Role.USER)));
+                tradeService.getExchangeItemTrackingNumber(tradeId, reqDto, new AuthUser(12L,"test@email.com", Role.USER)));
     }
 }

--- a/src/test/java/com/my/relink/service/TradeServiceTest.java
+++ b/src/test/java/com/my/relink/service/TradeServiceTest.java
@@ -324,6 +324,6 @@ class TradeServiceTest extends DummyObject {
 
         // When & Then
         assertThrows(BusinessException.class, () ->
-                tradeService.getExchangeItemTrackingNumber(tradeId, reqDto, new AuthUser(12L,"test@email.com", Role.USER)));
+                tradeService.getExchangeItemTrackingNumber(tradeId, reqDto, new AuthUser(12L, "test@email.com", Role.USER)));
     }
 }

--- a/src/test/java/com/my/relink/service/UserServiceTest.java
+++ b/src/test/java/com/my/relink/service/UserServiceTest.java
@@ -1,13 +1,6 @@
 package com.my.relink.service;
 
 
-
-import com.my.relink.domain.review.ReviewRepository;
-import com.my.relink.domain.user.User;
-import com.my.relink.util.DummyObject;
-import com.my.relink.domain.image.EntityType;
-import com.my.relink.domain.image.Image;
-import com.my.relink.domain.image.ImageRepository;
 import com.my.relink.controller.user.dto.req.*;
 import com.my.relink.controller.user.dto.resp.*;
 import com.my.relink.domain.image.EntityType;


### PR DESCRIPTION
## 💫 PR 개요
<!-- PR에 대한 간단한 설명 -->
교환 진행 페이지에서 운송장 번호 입력 받기
## 📌 관련 이슈
<!-- 이슈 연결 -->
- Closes #16 
- Resolves #16 

## 🛠 작업 내용
<!-- 구현한 내용을 자세히 설명 (시나리오나 구현 이유 등) -->
1. 로그인된 사용자가 요청자인지 소유자인지 확인
2. 해당되는 운송장 번호 필드에 저장
3. 둘 다 운송장 번호를 입력했다면 거래 상태를 in_delivery로 업데이트

## 리뷰 요청 사항
<!-- 리뷰어가 특별히 봐주었으면 하는 부분을 작성! -->

## 체크리스트
<!-- PR을 생성하기 전에 확인해야 할 사항들 -->
- [x] 코드 컨벤션을 준수하였습니다
- [x] 커밋 메시지를 컨벤션에 맞게 작성하였습니다
- [x] conflict가 모두 해결되었습니다
- [ ] 테스트 코드를 작성하였습니다
- [x] self review를 진행하였습니다