### PR TITLE
FEAT: 사용자 신뢰도 페이지 조회 기능 구현 

### DIFF
--- a/src/main/java/com/my/relink/controller/review/dto/resp/ReviewDetailWithExchangeItemListRespDto.java
+++ b/src/main/java/com/my/relink/controller/review/dto/resp/ReviewDetailWithExchangeItemListRespDto.java
@@ -1,0 +1,28 @@
+package com.my.relink.controller.review.dto.resp;
+
+import com.my.relink.domain.review.repository.dto.ReviewDetailWithExchangeItemRepositoryDto;
+import com.my.relink.util.DateTimeFormatterUtil;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.math.BigDecimal;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class ReviewDetailWithExchangeItemListRespDto {
+    private String exchangeItemName;
+    private String nickName;
+    private BigDecimal star;
+    private String description;
+    private String createAt;
+
+    public ReviewDetailWithExchangeItemListRespDto(ReviewDetailWithExchangeItemRepositoryDto dto) {
+        this.exchangeItemName = dto.getExchangeItemName();
+        this.nickName = dto.getNickName();
+        this.star = dto.getStar();
+        this.description = dto.getDescription();
+        this.createAt = DateTimeFormatterUtil.format(dto.getCreateAt());
+    }
+}

--- a/src/main/java/com/my/relink/controller/user/UserController.java
+++ b/src/main/java/com/my/relink/controller/user/UserController.java
@@ -10,6 +10,8 @@ import com.my.relink.service.UserService;
 import com.my.relink.util.api.ApiResult;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -84,5 +86,15 @@ public class UserController {
         return ResponseEntity
                 .status(HttpStatus.OK)
                 .body(ApiResult.success(userService.getUserProfile(authUser.getId())));
+    }
+
+    @GetMapping("/users/reliability")
+    public ResponseEntity<ApiResult<UserReliabilityPageRespDto>> myTrustPage(
+            @AuthenticationPrincipal AuthUser authUser,
+            @PageableDefault(size = 0, page = 10) Pageable pageable
+    ) {
+        return ResponseEntity
+                .status(HttpStatus.OK)
+                .body(ApiResult.success(userService.findReceivedReview(authUser.getId(), pageable)));
     }
 }

--- a/src/main/java/com/my/relink/controller/user/dto/resp/UserReliabilityPageRespDto.java
+++ b/src/main/java/com/my/relink/controller/user/dto/resp/UserReliabilityPageRespDto.java
@@ -1,0 +1,33 @@
+package com.my.relink.controller.user.dto.resp;
+
+import com.my.relink.controller.review.dto.resp.ReviewDetailWithExchangeItemListRespDto;
+import com.my.relink.util.page.PageResponse;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.domain.Page;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class UserReliabilityPageRespDto {
+    private int trustScore;
+    private Double avgStar;
+    private long totalExchangeItem;
+    private long totalDonationItem;
+
+    PageResponse<ReviewDetailWithExchangeItemListRespDto> reviews;
+
+    public UserReliabilityPageRespDto(
+            long totalExchangeItem,
+            long totalDonationItem,
+            Double avgStar,
+            Page<ReviewDetailWithExchangeItemListRespDto> page
+    ) {
+        this.trustScore = avgStar != null ? (int) (avgStar * 20) : 0;
+        this.avgStar = avgStar != null ? avgStar : 0.0;
+        this.totalExchangeItem = totalExchangeItem;
+        this.totalDonationItem = totalDonationItem;
+        this.reviews = PageResponse.of(page);
+    }
+}

--- a/src/main/java/com/my/relink/domain/item/donation/repository/DonationItemRepository.java
+++ b/src/main/java/com/my/relink/domain/item/donation/repository/DonationItemRepository.java
@@ -1,0 +1,10 @@
+package com.my.relink.domain.item.donation.repository;
+
+import com.my.relink.domain.item.donation.DonationItem;
+import com.my.relink.domain.item.donation.DonationStatus;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface DonationItemRepository extends JpaRepository<DonationItem, Long> {
+
+    long countByDonationStatusAndUserId(DonationStatus donationStatus, Long userId);
+}

--- a/src/main/java/com/my/relink/domain/item/exchange/repository/ExchangeItemRepository.java
+++ b/src/main/java/com/my/relink/domain/item/exchange/repository/ExchangeItemRepository.java
@@ -1,8 +1,10 @@
 package com.my.relink.domain.item.exchange.repository;
 
 import com.my.relink.domain.item.exchange.ExchangeItem;
+import com.my.relink.domain.trade.TradeStatus;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface ExchangeItemRepository extends JpaRepository<ExchangeItem, Long> {
 
+    long countByTradeStatusAndUserId(TradeStatus status, Long userId);
 }

--- a/src/main/java/com/my/relink/domain/review/repository/CustomReviewRepository.java
+++ b/src/main/java/com/my/relink/domain/review/repository/CustomReviewRepository.java
@@ -1,6 +1,7 @@
 package com.my.relink.domain.review.repository;
 
 import com.my.relink.domain.review.repository.dto.ReviewDetailRepositoryDto;
+import com.my.relink.domain.review.repository.dto.ReviewDetailWithExchangeItemRepositoryDto;
 import com.my.relink.domain.review.repository.dto.ReviewListRepositoryDto;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -17,4 +18,7 @@ public interface CustomReviewRepository {
 
     @Transactional(readOnly = true)
     Page<ReviewListRepositoryDto> findAllReviews(Long userId, Pageable pageable);
+
+    @Transactional(readOnly = true)
+    Page<ReviewDetailWithExchangeItemRepositoryDto> findReviewDetails(Long userId, Pageable pageable);
 }

--- a/src/main/java/com/my/relink/domain/review/repository/ReviewRepository.java
+++ b/src/main/java/com/my/relink/domain/review/repository/ReviewRepository.java
@@ -1,7 +1,6 @@
 package com.my.relink.domain.review.repository;
 
 import com.my.relink.domain.review.Review;
-import com.my.relink.domain.user.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -10,6 +9,6 @@ public interface ReviewRepository extends JpaRepository<Review, Long>, CustomRev
 
     @Query("select avg(r.star) " +
             "from Review r " +
-            "where r.exchangeItem.user = :user")
-    Double getTotalStarAvg(@Param("user") User user);
+            "where r.exchangeItem.user.id = :userId")
+    Double getTotalStarAvg(@Param("userId") Long userId);
 }

--- a/src/main/java/com/my/relink/domain/review/repository/dto/ReviewDetailWithExchangeItemRepositoryDto.java
+++ b/src/main/java/com/my/relink/domain/review/repository/dto/ReviewDetailWithExchangeItemRepositoryDto.java
@@ -1,0 +1,19 @@
+package com.my.relink.domain.review.repository.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class ReviewDetailWithExchangeItemRepositoryDto {
+    private String exchangeItemName;
+    private String nickName;
+    private BigDecimal star;
+    private String description;
+    private LocalDateTime createAt;
+}

--- a/src/main/java/com/my/relink/service/UserTrustScoreService.java
+++ b/src/main/java/com/my/relink/service/UserTrustScoreService.java
@@ -18,7 +18,7 @@ public class UserTrustScoreService {
      * @return 별점 평균 백분율 전환 값 (정수). 리뷰가 존재하지 않을 경우 0 반환
      */
     public int getTrustScore(User user) {
-        Double starAvg = reviewRepository.getTotalStarAvg(user);
+        Double starAvg = reviewRepository.getTotalStarAvg(user.getId());
         return starAvg == null ? 0 : (int) (starAvg * 20);
     }
 }

--- a/src/test/java/com/my/relink/ExchangeItem/ExchangeItemServiceTest.java
+++ b/src/test/java/com/my/relink/ExchangeItem/ExchangeItemServiceTest.java
@@ -131,6 +131,6 @@ class ExchangeItemServiceTest {
         // Then
         assertThatThrownBy(() -> exchangeItemService.createExchangeItem(reqDto, userId))
                 .isInstanceOf(BusinessException.class)
-                .hasMessageContaining("포인트가 부족합니다.");
+                .hasMessageContaining("포인트가 부족합니다");
     }
 }

--- a/src/test/java/com/my/relink/domain/like/repository/CustomLikeRepositoryImplTest.java
+++ b/src/test/java/com/my/relink/domain/like/repository/CustomLikeRepositoryImplTest.java
@@ -111,14 +111,14 @@ class CustomLikeRepositoryImplTest {
         // then
         assertThat(result.getContent()).hasSize(2);
         assertThat(result.getTotalElements()).isEqualTo(2);
-        LikeExchangeItemListRepositoryDto firstItem = result.getContent().get(0);
+        LikeExchangeItemListRepositoryDto firstItem = result.getContent().get(1);
         assertThat(firstItem.getItemId()).isEqualTo(item1.getId());
-        assertThat(firstItem.getItemName()).isEqualTo("item1");
+        assertThat(firstItem.getItemName()).isEqualTo(item1.getName());
         assertThat(firstItem.getTradeStatus()).isEqualTo(TradeStatus.AVAILABLE);
-        assertThat(firstItem.getDesiredItem()).isEqualTo("desired1");
-        assertThat(firstItem.getOwnerNickname()).isEqualTo("testUser");
-        assertThat(firstItem.getImageUrl()).isEqualTo("url1");
-        assertThat(firstItem.getAvgStar()).isEqualTo(4.5);
+        assertThat(firstItem.getDesiredItem()).isEqualTo(item1.getDesiredItem());
+        assertThat(firstItem.getOwnerNickname()).isEqualTo(item1.getUser().getNickname());
+        assertThat(firstItem.getImageUrl()).isEqualTo(image1.getImageUrl());
+        assertThat(firstItem.getAvgStar()).isEqualTo(review1.getStar().doubleValue());
     }
 
     @Test

--- a/src/test/java/com/my/relink/service/UserTrustScoreServiceTest.java
+++ b/src/test/java/com/my/relink/service/UserTrustScoreServiceTest.java
@@ -26,48 +26,48 @@ class UserTrustScoreServiceTest extends DummyObject {
     @DisplayName("유저 신뢰도 계산: 정상 케이스")
     void getTrustScore_success(){
         User user = mockRequesterUser();
-        when(reviewRepository.getTotalStarAvg(user)).thenReturn(4.5);
+        when(reviewRepository.getTotalStarAvg(user.getId())).thenReturn(4.5);
 
         int trustScore = userTrustScoreService.getTrustScore(user);
 
         assertThat(trustScore).isEqualTo(90);
-        verify(reviewRepository, times(1)).getTotalStarAvg(user);
+        verify(reviewRepository, times(1)).getTotalStarAvg(user.getId());
     }
 
     @Test
     @DisplayName("유저 신뢰도 점수 계산: 리뷰가 없는 경우 신뢰도는 0이어야 한다")
     void getTrustScore_NoReviews() {
         User user = mockRequesterUser();
-        when(reviewRepository.getTotalStarAvg(user)).thenReturn(null);
+        when(reviewRepository.getTotalStarAvg(user.getId())).thenReturn(null);
 
         int trustScore = userTrustScoreService.getTrustScore(user);
 
         assertThat(trustScore).isEqualTo(0);
-        verify(reviewRepository, times(1)).getTotalStarAvg(user);
+        verify(reviewRepository, times(1)).getTotalStarAvg(user.getId());
     }
 
     @Test
     @DisplayName("유저 신뢰도 점수 계산: 최대 점수는 100이어야 한다")
     void getTrustScore_MaxScore() {
         User user = mockRequesterUser();
-        when(reviewRepository.getTotalStarAvg(user)).thenReturn(5.0);
+        when(reviewRepository.getTotalStarAvg(user.getId())).thenReturn(5.0);
 
         int trustScore = userTrustScoreService.getTrustScore(user);
 
         assertThat(trustScore).isEqualTo(100);
-        verify(reviewRepository, times(1)).getTotalStarAvg(user);
+        verify(reviewRepository, times(1)).getTotalStarAvg(user.getId());
     }
 
     @Test
     @DisplayName("유저 신뢰도 점수 계산: 최소 점수는 10이어야 한다")
     void getTrustScore_MinScore() {
         User user = mockRequesterUser();
-        when(reviewRepository.getTotalStarAvg(user)).thenReturn(0.5);
+        when(reviewRepository.getTotalStarAvg(user.getId())).thenReturn(0.5);
 
         int trustScore = userTrustScoreService.getTrustScore(user);
 
         assertThat(trustScore).isEqualTo(10);
-        verify(reviewRepository, times(1)).getTotalStarAvg(user);
+        verify(reviewRepository, times(1)).getTotalStarAvg(user.getId());
     }
 
 }


### PR DESCRIPTION
## 💫 PR 개요
사용자 신뢰도 페이지 

## 📌 관련 이슈
<!-- 이슈 연결 -->
- OPEN #51 

## 🛠 작업 내용
<!-- 구현한 내용을 자세히 설명 (시나리오나 구현 이유 등) -->
1. 지금까지 교환이 완료된 교환 상품 카운팅 
2. 지금까지 교환이 완료된 기부 상품 카운팅 
3. 사용자에게 달린 평균 벌점을 ReviewRepository에서 가져와 신뢰도와 평균별점 응답 
4. 리뷰 정보에 대한 Page 리스트 응답 

## 리뷰 요청 사항
<!-- 리뷰어가 특별히 봐주었으면 하는 부분을 작성! -->

## 체크리스트
<!-- PR을 생성하기 전에 확인해야 할 사항들 -->
- [ ] 코드 컨벤션을 준수하였습니다
- [ ] 커밋 메시지를 컨벤션에 맞게 작성하였습니다
- [ ] conflict가 모두 해결되었습니다
- [ ] 테스트 코드를 작성하였습니다
- [ ] self review를 진행하였습니다