### PR TITLE
FEAT: 사용자 프로필 사진 삭제 기능 

### DIFF
--- a/src/main/java/com/my/relink/controller/image/ImageController.java
+++ b/src/main/java/com/my/relink/controller/image/ImageController.java
@@ -2,15 +2,14 @@ package com.my.relink.controller.image;
 
 import com.my.relink.config.security.AuthUser;
 import com.my.relink.controller.image.dto.resp.ImageUserProfileCreateRespDto;
+import com.my.relink.controller.image.dto.resp.ImageUserProfileDeleteRespDto;
 import com.my.relink.service.ImageService;
 import com.my.relink.util.api.ApiResult;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 
 @RestController
@@ -27,5 +26,15 @@ public class ImageController {
         return ResponseEntity
                 .status(HttpStatus.CREATED)
                 .body(ApiResult.success(imageService.addUserProfile(authUser.getId(), file)));
+    }
+
+    @DeleteMapping("/users/images/{imageId}")
+    public ResponseEntity<ApiResult<ImageUserProfileDeleteRespDto>> deleteUserProfile(
+            @PathVariable Long imageId,
+            @AuthenticationPrincipal AuthUser authUser
+    ) {
+        return ResponseEntity
+                .status(HttpStatus.OK)
+                .body(ApiResult.success(imageService.deleteUserProfile(authUser.getId(), imageId)));
     }
 }

--- a/src/main/java/com/my/relink/controller/image/dto/resp/ImageUserProfileDeleteRespDto.java
+++ b/src/main/java/com/my/relink/controller/image/dto/resp/ImageUserProfileDeleteRespDto.java
@@ -1,0 +1,12 @@
+package com.my.relink.controller.image.dto.resp;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class ImageUserProfileDeleteRespDto {
+    private Long imageId;
+}

--- a/src/main/java/com/my/relink/domain/image/repository/ImageRepository.java
+++ b/src/main/java/com/my/relink/domain/image/repository/ImageRepository.java
@@ -13,4 +13,5 @@ public interface ImageRepository extends JpaRepository<Image, Long>, CustomImage
 
     Optional<Image> findByEntityIdAndEntityType(Long entityId, EntityType entityType);
 
+    Optional<Image> findByIdAndEntityIdAndEntityType(Long id, Long entityId, EntityType type);
 }

--- a/src/main/java/com/my/relink/ex/ErrorCode.java
+++ b/src/main/java/com/my/relink/ex/ErrorCode.java
@@ -33,6 +33,8 @@ public enum ErrorCode {
     FILE_SIZE_EXCEEDED(HttpStatus.BAD_REQUEST.value(), "파일 크기를 초과하였습니다."),
     INVALID_FILE_EXTENSION(HttpStatus.BAD_REQUEST.value(), "지원하지 않는 파일 형식입니다."),
     ALREADY_IMAGE_FILE(HttpStatus.BAD_REQUEST.value(), "프로필 이미지는 하나만 등록할 수 있습니다."),
+    IMAGE_NOT_FOUND(HttpStatus.NOT_FOUND.value(), "이미지를 찾을 수 없습니다."),
+    IMAGE_ACCESS_DENIED(HttpStatus.BAD_REQUEST.value(), "해당 이미지의 소유자와 다릅니다.");
 
     ;
 

--- a/src/main/java/com/my/relink/service/ImageService.java
+++ b/src/main/java/com/my/relink/service/ImageService.java
@@ -61,12 +61,8 @@ public class ImageService {
 
     @Transactional
     public ImageUserProfileDeleteRespDto deleteUserProfile(Long userId, Long imageId) {
-        Image image = imageRepository.findById(imageId)
+        Image image = imageRepository.findByIdAndEntityIdAndEntityType(imageId, userId, EntityType.USER)
                 .orElseThrow(() -> new BusinessException(ErrorCode.IMAGE_NOT_FOUND));
-
-        if (!image.getEntityId().equals(userId)) {
-            throw new BusinessException(ErrorCode.IMAGE_ACCESS_DENIED);
-        }
 
         s3Service.deleteImage(image.getImageUrl());
         imageRepository.delete(image);

--- a/src/test/java/com/my/relink/service/ExchangeItemServiceTest.java
+++ b/src/test/java/com/my/relink/service/ExchangeItemServiceTest.java
@@ -310,7 +310,7 @@ class ExchangeItemServiceTest {
         BusinessException exception = Assertions.assertThrows(BusinessException.class, () -> {
             exchangeItemService.getExchangeItemModifyPage(itemId, userId);
         });
-        Assertions.assertEquals(ErrorCode.ITEM_NOT_FOUND, exception.getErrorCode());
+        Assertions.assertEquals(ErrorCode.EXCHANGE_ITEM_NOT_FOUND, exception.getErrorCode());
     }
 
     @Test

--- a/src/test/java/com/my/relink/service/ImageServiceTest.java
+++ b/src/test/java/com/my/relink/service/ImageServiceTest.java
@@ -95,11 +95,11 @@ class ImageServiceTest {
         Long userId = 1L;
         Long imageId = 1L;
 
-        when(imageRepository.findById(userId)).thenReturn(Optional.empty());
+        when(imageRepository.findByIdAndEntityIdAndEntityType(userId, imageId, EntityType.USER)).thenReturn(Optional.empty());
 
         // when & then
         assertThrows(BusinessException.class, () -> imageService.deleteUserProfile(userId, imageId));
-        verify(imageRepository, times(1)).findById(any());
+        verify(imageRepository, times(1)).findByIdAndEntityIdAndEntityType(any(), any(), any());
     }
 
     @Test
@@ -115,11 +115,11 @@ class ImageServiceTest {
                 .entityType(EntityType.USER)
                 .build();
 
-        when(imageRepository.findById(imageId)).thenReturn(Optional.of(image));
+        when(imageRepository.findByIdAndEntityIdAndEntityType(imageId, userId, EntityType.USER)).thenReturn(Optional.empty());
 
         // when & then
         assertThrows(BusinessException.class, () -> imageService.deleteUserProfile(userId, imageId));
-        verify(imageRepository, times(1)).findById(any());
+        verify(imageRepository, times(1)).findByIdAndEntityIdAndEntityType(any(), any(), any());
     }
 
     @Test
@@ -135,7 +135,7 @@ class ImageServiceTest {
                 .entityType(EntityType.USER)
                 .build();
 
-        when(imageRepository.findById(imageId)).thenReturn(Optional.of(image));
+        when(imageRepository.findByIdAndEntityIdAndEntityType(imageId, userId, EntityType.USER)).thenReturn(Optional.of(image));
         doNothing().when(imageRepository).delete(image);
         doNothing().when(s3Service).deleteImage(image.getImageUrl());
 
@@ -145,7 +145,7 @@ class ImageServiceTest {
         // then
         assertThat(result).isNotNull();
         assertThat(result.getImageId()).isEqualTo(imageId);
-        verify(imageRepository, times(1)).findById(any());
+        verify(imageRepository, times(1)).findByIdAndEntityIdAndEntityType(any(), any(), any());
         verify(imageRepository, times(1)).delete(any());
         verify(s3Service, times(1)).deleteImage(any());
     }

--- a/src/test/java/com/my/relink/service/TradeServiceTest.java
+++ b/src/test/java/com/my/relink/service/TradeServiceTest.java
@@ -342,7 +342,7 @@ class TradeServiceTest extends DummyObject {
 
     @Test
     @DisplayName("교환 진행 페이지 : 조회 성공 케이스")
-    void testFindTradeCompletionInfo_success() {
+    void testFindTradeCompletionInfo_success() { // stubbing 수정 필요
         Long tradeId = 1L;
         User requester = mockRequesterUser();
         User owner = mockOwnerUser();
@@ -365,12 +365,12 @@ class TradeServiceTest extends DummyObject {
         User partnerUser = trade.getPartner(requester.getId());  // 거래 상대방 (소유자)
 
         Mockito.when(userRepository.findById(requester.getId())).thenReturn(Optional.of(requester));
-        Mockito.when(userRepository.findById(owner.getId())).thenReturn(Optional.of(owner));
+//        Mockito.when(userRepository.findById(owner.getId())).thenReturn(Optional.of(owner));
         Mockito.when(tradeRepository.findTradeWithDetails(tradeId)).thenReturn(Optional.of(trade));
         Mockito.when(imageService.getExchangeItemUrl(myExchangeItem)).thenReturn(myImageUrl);
         Mockito.when(imageService.getExchangeItemUrl(partnerExchangeItem)).thenReturn(partnerImageUrl);
 
-        Mockito.when(userRepository.findById(trade.getPartner(requester.getId()).getId())).thenReturn(Optional.of(partnerUser));
+//        Mockito.when(userRepository.findById(trade.getPartner(requester.getId()).getId())).thenReturn(Optional.of(partnerUser));
         Mockito.when(dateTimeUtil.getTradeStatusFormattedTime(trade.getModifiedAt()))
                 .thenReturn("2024년 12월 12일 14:30");
 
@@ -417,7 +417,7 @@ class TradeServiceTest extends DummyObject {
 
 
         Mockito.when(userRepository.findById(requester.getId())).thenReturn(Optional.of(requester));
-        Mockito.when(tradeRepository.findById(tradeId)).thenReturn(Optional.empty());  // 거래가 없음
+        Mockito.when(tradeRepository.findTradeWithDetails(tradeId)).thenReturn(Optional.empty());  // 거래가 없음
 
         BusinessException exception = assertThrows(
                 BusinessException.class,

--- a/src/test/java/com/my/relink/service/UserServiceTest.java
+++ b/src/test/java/com/my/relink/service/UserServiceTest.java
@@ -257,7 +257,7 @@ class UserServiceTest extends DummyObject {
         when(userRepository.findById(userId)).thenReturn(Optional.empty());
         // when & then
         assertThrows(BusinessException.class, () -> userService.deleteUser(userId, reqDto));
-        verify(userRepository, times(1)).findByEmail(any());
+        verify(userRepository, times(1)).findById(any());
     }
 
     @Test
@@ -281,7 +281,7 @@ class UserServiceTest extends DummyObject {
 
         // when & then
         assertThrows(BusinessException.class, () -> userService.deleteUser(userId, reqDto));
-        verify(userRepository, times(1)).findByEmail(any());
+        verify(userRepository, times(1)).findById(any());
     }
 
     @Test
@@ -307,7 +307,7 @@ class UserServiceTest extends DummyObject {
         userService.deleteUser(userId, reqDto);
 
         // then
-        verify(userRepository, times(1)).findByEmail(any());
+        verify(userRepository, times(1)).findById(any());
         verify(passwordEncoder, times(1)).matches(any(), any());
     }
 


### PR DESCRIPTION
## 💫 PR 개요
사용자 프로필 삭제 기능 

## 📌 관련 이슈
<!-- 이슈 연결 -->
- OPEN #130 

## 🛠 작업 내용
<!-- 구현한 내용을 자세히 설명 (시나리오나 구현 이유 등) -->
1. 사용자 프로필 삭제 시 데이터 정합성을 체크합니다. 
2. 사용자 프로필 삭제할때에는 DB 와 S3 에서 해당 이미지를 삭제합니다.

## 리뷰 요청 사항
<!-- 리뷰어가 특별히 봐주었으면 하는 부분을 작성! -->

## 체크리스트
<!-- PR을 생성하기 전에 확인해야 할 사항들 -->
- [ ] 코드 컨벤션을 준수하였습니다
- [ ] 커밋 메시지를 컨벤션에 맞게 작성하였습니다
- [ ] conflict가 모두 해결되었습니다
- [ ] 테스트 코드를 작성하였습니다
- [ ] self review를 진행하였습니다