### PR TITLE
FIX: 회원 탈퇴 시 교환 가능 상품을 교환 불가로 변경 

### DIFF
--- a/src/main/java/com/my/relink/domain/item/exchange/repository/ExchangeItemRepository.java
+++ b/src/main/java/com/my/relink/domain/item/exchange/repository/ExchangeItemRepository.java
@@ -5,6 +5,7 @@ import com.my.relink.domain.trade.TradeStatus;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
@@ -12,7 +13,11 @@ import java.util.Optional;
 
 public interface ExchangeItemRepository extends JpaRepository<ExchangeItem, Long> {
 
-
     long countByTradeStatusAndUserId(TradeStatus status, Long userId);
+
     Page<ExchangeItem> findByUserId(Long id, Pageable pageable);
+
+    @Modifying(clearAutomatically = true)
+    @Query("update ExchangeItem e set e.tradeStatus = com.my.relink.domain.trade.TradeStatus.UNAVAILABLE where e.user.id = :userId")
+    void updateTradeStatusToUnavailable(@Param("userId") Long userId);
 }

--- a/src/main/java/com/my/relink/service/UserService.java
+++ b/src/main/java/com/my/relink/service/UserService.java
@@ -5,6 +5,7 @@ import com.my.relink.controller.user.dto.resp.*;
 import com.my.relink.domain.image.EntityType;
 import com.my.relink.domain.image.Image;
 import com.my.relink.domain.image.repository.ImageRepository;
+import com.my.relink.domain.item.exchange.repository.ExchangeItemRepository;
 import com.my.relink.domain.point.Point;
 import com.my.relink.domain.point.repository.PointRepository;
 import com.my.relink.domain.review.repository.ReviewRepository;
@@ -16,6 +17,7 @@ import com.my.relink.ex.ErrorCode;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
@@ -26,8 +28,9 @@ public class UserService {
     private final ImageRepository imageRepository;
     private final PointRepository pointRepository;
     private final ReviewRepository reviewRepository;
+    private final ExchangeItemRepository exchangeItemRepository;
 
-    public User findByIdOrFail(Long userId){
+    public User findByIdOrFail(Long userId) {
         return userRepository.findById(userId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
     }
@@ -77,6 +80,7 @@ public class UserService {
         userRepository.save(user);
     }
 
+    @Transactional
     public void deleteUser(UserDeleteReqDto dto) {
         User user = userRepository.findByEmail(dto.getEmail())
                 .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
@@ -87,6 +91,7 @@ public class UserService {
 
         user.changeIsDeleted();
         userRepository.save(user);
+        exchangeItemRepository.updateTradeStatusToUnavailable(user.getId());
     }
 
     public UserValidNicknameRespDto validNickname(UserValidNicknameRepDto dto) {

--- a/src/test/java/com/my/relink/controller/message/MessageControllerTest.java
+++ b/src/test/java/com/my/relink/controller/message/MessageControllerTest.java
@@ -11,21 +11,18 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.util.ReflectionTestUtils;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
 
 import java.time.Clock;
-import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.ZoneOffset;
-import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.List;
 
-import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
@@ -38,7 +35,7 @@ class MessageControllerTest {
     @Autowired
     MockMvc mvc;
 
-    @MockBean
+    @MockitoBean
     MessageService messageService;
 
     @Nested
@@ -49,7 +46,7 @@ class MessageControllerTest {
 
         private final LocalDateTime FIXED_NOW = LocalDateTime.of(2024, 12, 10, 15, 0);
         private final Clock fixedClock = Clock.fixed(FIXED_NOW.toInstant(ZoneOffset.UTC), ZoneOffset.UTC);
-        @MockBean
+        @MockitoBean
         private DateTimeUtil dateTimeUtil;
 
         private final LocalDateTime TODAY_MESSAGE = FIXED_NOW.minusHours(2);

--- a/src/test/java/com/my/relink/domain/item/exchange/repository/ExchangeItemRepositoryTest.java
+++ b/src/test/java/com/my/relink/domain/item/exchange/repository/ExchangeItemRepositoryTest.java
@@ -1,0 +1,74 @@
+package com.my.relink.domain.item.exchange.repository;
+
+import com.my.relink.config.JpaConfig;
+import com.my.relink.config.TestConfig;
+import com.my.relink.domain.item.exchange.ExchangeItem;
+import com.my.relink.domain.trade.TradeStatus;
+import com.my.relink.domain.user.User;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
+import org.springframework.context.annotation.Import;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DataJpaTest
+@Import({TestConfig.class, JpaConfig.class})
+class ExchangeItemRepositoryTest {
+
+    @Autowired
+    TestEntityManager em;
+
+    @Autowired
+    ExchangeItemRepository exchangeItemRepository;
+
+    @Test
+    @DisplayName("TradeStatus를 벌크 연산 할때 정상 동작한다.")
+    void bulkTradeStatusSuccessTest() {
+        // given
+        User user = User.builder()
+                .name("test")
+                .password("test")
+                .build();
+
+        ExchangeItem item1 = ExchangeItem.builder()
+                .name("item1")
+                .user(user)
+                .tradeStatus(TradeStatus.EXCHANGED)
+                .isDeleted(false)
+                .build();
+
+        ExchangeItem item2 = ExchangeItem.builder()
+                .name("item2")
+                .user(user)
+                .tradeStatus(TradeStatus.EXCHANGED)
+                .isDeleted(false)
+                .build();
+
+        em.persist(user);
+        em.persist(item1);
+        em.persist(item2);
+
+        em.flush();
+        em.clear();
+
+        // when
+        exchangeItemRepository.updateTradeStatusToUnavailable(user.getId());
+
+        // then
+        Pageable pageable = PageRequest.of(0, 10);
+        Page<ExchangeItem> result = exchangeItemRepository.findByUserId(user.getId(), pageable);
+
+        List<ExchangeItem> content = result.getContent();
+        assertThat(content).isNotNull();
+        assertThat(content.get(0).getTradeStatus()).isEqualTo(TradeStatus.UNAVAILABLE);
+        assertThat(content.get(1).getTradeStatus()).isEqualTo(TradeStatus.UNAVAILABLE);
+    }
+}

--- a/src/test/java/com/my/relink/service/UserServiceTest.java
+++ b/src/test/java/com/my/relink/service/UserServiceTest.java
@@ -6,8 +6,11 @@ import com.my.relink.controller.user.dto.resp.*;
 import com.my.relink.domain.image.EntityType;
 import com.my.relink.domain.image.Image;
 import com.my.relink.domain.image.repository.ImageRepository;
+import com.my.relink.domain.item.exchange.ExchangeItem;
+import com.my.relink.domain.item.exchange.repository.ExchangeItemRepository;
 import com.my.relink.domain.point.Point;
 import com.my.relink.domain.point.repository.PointRepository;
+import com.my.relink.domain.trade.TradeStatus;
 import com.my.relink.domain.user.Address;
 import com.my.relink.domain.user.User;
 import com.my.relink.domain.user.repository.UserRepository;
@@ -45,6 +48,9 @@ class UserServiceTest extends DummyObject {
 
     @Mock
     private PointRepository pointRepository;
+
+    @Mock
+    private ExchangeItemRepository exchangeItemRepository;
 
     @Test
     @DisplayName("정상적인 회원가입 성공")
@@ -431,5 +437,38 @@ class UserServiceTest extends DummyObject {
         // when & then
         assertThrows(BusinessException.class, () -> userService.findUserPoint(userId));
         verify(userRepository, times(1)).findById(any());
+    }
+
+    @Test
+    @DisplayName("회원 탈퇴시 회원이 등록한 교환아이템들을 전부 교환 불가 상태로 변경한다.")
+    void deleteUserWithExchangeItemStatusToUnavailableSuccessTest() {
+        // given
+        String email = "test@example.com";
+
+        UserDeleteReqDto reqDto = UserDeleteReqDto.builder()
+                .email("test@example.com")
+                .password("test")
+                .build();
+
+        User user = User.builder()
+                .id(1L)
+                .name("test")
+                .password("test")
+                .build();
+
+        when(userRepository.findByEmail(email)).thenReturn(Optional.of(user));
+        when(passwordEncoder.matches(any(), any())).thenReturn(true);
+        when(userRepository.save(any(User.class))).thenReturn(user);
+
+        doNothing().when(exchangeItemRepository).updateTradeStatusToUnavailable(user.getId());
+
+        // when
+        userService.deleteUser(reqDto);
+
+        // then
+        verify(userRepository, times(1)).findByEmail(any());
+        verify(passwordEncoder, times(1)).matches(any(), any());
+        verify(userRepository, times(1)).save(any());
+        verify(exchangeItemRepository, times(1)).updateTradeStatusToUnavailable(any());
     }
 }


### PR DESCRIPTION
## 💫 PR 개요
회원 탈퇴 시 교환 가능 상품을 교환 불가로 전부 변경 

## 📌 관련 이슈
<!-- 이슈 연결 -->
- OPEN #97 

## 🛠 작업 내용
<!-- 구현한 내용을 자세히 설명 (시나리오나 구현 이유 등) -->
1. 벌크 연산으로 UserId 를 통해 교환 상품 상태 변경 

## 리뷰 요청 사항
<!-- 리뷰어가 특별히 봐주었으면 하는 부분을 작성! -->

## 체크리스트
<!-- PR을 생성하기 전에 확인해야 할 사항들 -->
- [ ] 코드 컨벤션을 준수하였습니다
- [ ] 커밋 메시지를 컨벤션에 맞게 작성하였습니다
- [ ] conflict가 모두 해결되었습니다
- [ ] 테스트 코드를 작성하였습니다
- [ ] self review를 진행하였습니다