### PR TITLE
FIX:  탈퇴한 사용자 로그인 불가 처리 

### DIFF
--- a/src/main/java/com/my/relink/config/security/LoginAuthenticationProvider.java
+++ b/src/main/java/com/my/relink/config/security/LoginAuthenticationProvider.java
@@ -24,7 +24,7 @@ public class LoginAuthenticationProvider implements AuthenticationProvider {
         String email = loginAuthentication.getName();
         String password = (String) loginAuthentication.getCredentials();
 
-        User user = userRepository.findByEmail(email)
+        User user = userRepository.findByEmailActiveUser(email)
                 .orElseThrow(() -> new SecurityFilterChainException(ErrorCode.USER_NOT_FOUND));
 
         if (!passwordEncoder.matches(password, user.getPassword())) {

--- a/src/main/java/com/my/relink/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/my/relink/domain/user/repository/UserRepository.java
@@ -3,6 +3,7 @@ package com.my.relink.domain.user.repository;
 import com.my.relink.domain.user.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.Optional;
 
@@ -11,5 +12,6 @@ public interface UserRepository extends JpaRepository<User, Long>, CustomUserRep
 
     Optional<User> findByNickname(String nickname);
 
-
+    @Query("select u from User u where u.email = :email and u.isDeleted = false")
+    Optional<User> findByEmailActiveUser(@Param("email") String email);
 }

--- a/src/test/java/com/my/relink/config/TestConfig.java
+++ b/src/test/java/com/my/relink/config/TestConfig.java
@@ -1,9 +1,14 @@
 package com.my.relink.config;
 
+import com.my.relink.util.DateTimeUtil;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import jakarta.persistence.EntityManager;
 import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.context.annotation.Bean;
+
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneId;
 
 @TestConfiguration
 public class TestConfig {
@@ -11,5 +16,30 @@ public class TestConfig {
     @Bean
     public JPAQueryFactory jpaQueryFactory(EntityManager em) {
         return new JPAQueryFactory(em);
+    }
+
+    @Bean
+    public DateTimeUtil dateTimeUtil() {
+        return new DateTimeUtil(clock());
+    }
+
+    @Bean
+    public Clock clock() {
+        return new Clock() {
+            @Override
+            public ZoneId getZone() {
+                return null;
+            }
+
+            @Override
+            public Clock withZone(ZoneId zone) {
+                return null;
+            }
+
+            @Override
+            public Instant instant() {
+                return null;
+            }
+        };
     }
 }

--- a/src/test/java/com/my/relink/domain/review/repository/CustomReviewRepositoryImplTest.java
+++ b/src/test/java/com/my/relink/domain/review/repository/CustomReviewRepositoryImplTest.java
@@ -1,5 +1,6 @@
 package com.my.relink.domain.review.repository;
 
+import com.my.relink.config.JpaConfig;
 import com.my.relink.config.TestConfig;
 import com.my.relink.domain.image.EntityType;
 import com.my.relink.domain.image.Image;
@@ -13,6 +14,7 @@ import com.my.relink.domain.trade.Trade;
 import com.my.relink.domain.trade.TradeStatus;
 import com.my.relink.domain.user.Address;
 import com.my.relink.domain.user.User;
+import com.my.relink.util.DateTimeUtil;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -29,7 +31,7 @@ import java.util.List;
 import static org.assertj.core.api.Assertions.assertThat;
 
 @DataJpaTest
-@Import(TestConfig.class)
+@Import({TestConfig.class, JpaConfig.class})
 class CustomReviewRepositoryImplTest {
 
     @Autowired

--- a/src/test/java/com/my/relink/service/LikeServiceTest.java
+++ b/src/test/java/com/my/relink/service/LikeServiceTest.java
@@ -1,6 +1,7 @@
 package com.my.relink.service;
 
 import com.my.relink.domain.item.exchange.ExchangeItem;
+import com.my.relink.domain.item.exchange.repository.ExchangeItemRepository;
 import com.my.relink.domain.like.Like;
 import com.my.relink.domain.like.repository.LikeRepository;
 import com.my.relink.domain.user.User;
@@ -25,7 +26,7 @@ class LikeServiceTest {
     @Mock
     private LikeRepository likeRepository;
     @Mock
-    private ExchangeItemService exchangeItemService;
+    private ExchangeItemRepository exchangeItemRepository;
     @Mock
     private UserService userService;
 
@@ -38,7 +39,7 @@ class LikeServiceTest {
         ExchangeItem exchangeItem = mock(ExchangeItem.class);
 
         when(userService.findByIdOrFail(userId)).thenReturn(user);
-        when(exchangeItemService.findByIdOrFail(itemId)).thenReturn(exchangeItem);
+        when(exchangeItemRepository.findById(itemId)).thenReturn(Optional.of(exchangeItem));
         when(likeRepository.findByUserAndExchangeItem(user, exchangeItem)).thenReturn(Optional.empty());
         Like newLike = Like.builder()
                 .user(user)
@@ -68,7 +69,7 @@ class LikeServiceTest {
                 .build();
 
         when(userService.findByIdOrFail(userId)).thenReturn(user);
-        when(exchangeItemService.findByIdOrFail(itemId)).thenReturn(exchangeItem);
+        when(exchangeItemRepository.findById(itemId)).thenReturn(Optional.of(exchangeItem));
         when(likeRepository.findByUserAndExchangeItem(user, exchangeItem)).thenReturn(Optional.of(existingLike));
 
         Long deletedLikeId = likeService.toggleLike(userId, itemId);


### PR DESCRIPTION
## 💫 PR 개요
탈퇴한 사용자 로그인 못하도록 구현 

## 📌 관련 이슈
<!-- 이슈 연결 -->
- OPEN #152 

## 🛠 작업 내용
<!-- 구현한 내용을 자세히 설명 (시나리오나 구현 이유 등) -->
1. AuthenticationProvider 에서 탈퇴하지 않은 사용자만 찾도록 변경 
2. UserRepository 에서 탈퇴하지 않은 사용자만 찾도록 메서드 구현 

## 리뷰 요청 사항
<!-- 리뷰어가 특별히 봐주었으면 하는 부분을 작성! -->

## 체크리스트
<!-- PR을 생성하기 전에 확인해야 할 사항들 -->
- [ ] 코드 컨벤션을 준수하였습니다
- [ ] 커밋 메시지를 컨벤션에 맞게 작성하였습니다
- [ ] conflict가 모두 해결되었습니다
- [ ] 테스트 코드를 작성하였습니다
- [ ] self review를 진행하였습니다