### PR TITLE
Feat : 교환 상품 찜/해제 하기

### DIFF
--- a/src/main/java/com/my/relink/controller/like/LikeController.java
+++ b/src/main/java/com/my/relink/controller/like/LikeController.java
@@ -12,6 +12,8 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -28,5 +30,12 @@ public class LikeController {
         return ResponseEntity
                 .status(HttpStatus.OK)
                 .body(ApiResult.success(likeService.getLikeItemList(authUser.getId(), pageable)));
+    }
+
+    @PostMapping("/items/exchanges/{itemId}/like")
+    public ResponseEntity<ApiResult<Long>> toggleLike(@PathVariable(value = "itemId") Long itemId,
+                                                      @AuthenticationPrincipal AuthUser authUser) {
+        Long likeId = likeService.toggleLike(authUser.getId(), itemId);
+        return ResponseEntity.ok(ApiResult.success(likeId));
     }
 }

--- a/src/main/java/com/my/relink/domain/like/Like.java
+++ b/src/main/java/com/my/relink/domain/like/Like.java
@@ -4,10 +4,7 @@ import com.my.relink.domain.BaseEntity;
 import com.my.relink.domain.item.exchange.ExchangeItem;
 import com.my.relink.domain.user.User;
 import jakarta.persistence.*;
-import lombok.AccessLevel;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -15,7 +12,8 @@ import lombok.NoArgsConstructor;
 @Table(name = "likes")
 public class Like extends BaseEntity {
 
-    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
     @ManyToOne(fetch = FetchType.LAZY)

--- a/src/main/java/com/my/relink/domain/like/repository/LikeRepository.java
+++ b/src/main/java/com/my/relink/domain/like/repository/LikeRepository.java
@@ -9,6 +9,4 @@ import java.util.Optional;
 
 public interface LikeRepository extends JpaRepository<Like, Long>, CustomLikeRepository {
     Optional<Like> findByUserAndExchangeItem(User user, ExchangeItem exchangeItem);
-
-    void deleteByUserAndExchangeItem(User user, ExchangeItem exchangeItem);
 }

--- a/src/main/java/com/my/relink/domain/like/repository/LikeRepository.java
+++ b/src/main/java/com/my/relink/domain/like/repository/LikeRepository.java
@@ -1,7 +1,14 @@
 package com.my.relink.domain.like.repository;
 
+import com.my.relink.domain.item.exchange.ExchangeItem;
 import com.my.relink.domain.like.Like;
+import com.my.relink.domain.user.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface LikeRepository extends JpaRepository<Like, Long> , CustomLikeRepository{
+import java.util.Optional;
+
+public interface LikeRepository extends JpaRepository<Like, Long>, CustomLikeRepository {
+    Optional<Like> findByUserAndExchangeItem(User user, ExchangeItem exchangeItem);
+
+    void deleteByUserAndExchangeItem(User user, ExchangeItem exchangeItem);
 }

--- a/src/main/java/com/my/relink/service/LikeService.java
+++ b/src/main/java/com/my/relink/service/LikeService.java
@@ -1,22 +1,50 @@
 package com.my.relink.service;
 
 import com.my.relink.controller.like.dto.resp.LikeExchangeItemListRespDto;
+import com.my.relink.domain.item.exchange.ExchangeItem;
+import com.my.relink.domain.like.Like;
 import com.my.relink.domain.like.repository.LikeRepository;
 import com.my.relink.domain.like.repository.dto.LikeExchangeItemListRepositoryDto;
+import com.my.relink.domain.user.User;
 import com.my.relink.util.page.PageResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Optional;
 
 @Service
 @RequiredArgsConstructor
 public class LikeService {
     private final LikeRepository likeRepository;
+    private final ExchangeItemService exchangeItemService;
 
     public PageResponse<LikeExchangeItemListRespDto> getLikeItemList(Long userId, Pageable pageable) {
         Page<LikeExchangeItemListRepositoryDto> likeExchangeItem
                 = likeRepository.findUserLikeExchangeItem(userId, pageable);
         return PageResponse.of(likeExchangeItem.map(LikeExchangeItemListRespDto::new));
+    }
+
+    @Transactional
+    public Long toggleLike(Long userId, Long itemId) {
+        User user = exchangeItemService.getValidUser(userId);
+        ExchangeItem exchangeItem = exchangeItemService.findByIdOrFail(itemId);
+
+        Optional<Like> existingLike = likeRepository.findByUserAndExchangeItem(user, exchangeItem);
+
+        if (existingLike.isPresent()) {
+            Long likeId = existingLike.get().getId();
+            likeRepository.deleteByUserAndExchangeItem(user, exchangeItem);
+            return likeId;
+        } else {
+            Like like = Like.builder()
+                    .user(user)
+                    .exchangeItem(exchangeItem)
+                    .build();
+            Like savedLike = likeRepository.save(like);
+            return savedLike.getId();
+        }
     }
 }

--- a/src/test/java/com/my/relink/service/ExchangeItemServiceTest.java
+++ b/src/test/java/com/my/relink/service/ExchangeItemServiceTest.java
@@ -24,10 +24,12 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.MockitoAnnotations;
+import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
@@ -45,7 +47,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 
-
+@ExtendWith(MockitoExtension.class)
 class ExchangeItemServiceTest {
     @InjectMocks
     private ExchangeItemService exchangeItemService;
@@ -62,11 +64,6 @@ class ExchangeItemServiceTest {
     private TradeService tradeService;
     @Mock
     private ImageService imageService;
-
-    @BeforeEach
-    void setUp() {
-        MockitoAnnotations.openMocks(this);
-    }
 
     @Test
     @DisplayName("내 교환상품 생성하기 성공")

--- a/src/test/java/com/my/relink/service/LikeServiceTest.java
+++ b/src/test/java/com/my/relink/service/LikeServiceTest.java
@@ -1,0 +1,79 @@
+package com.my.relink.service;
+
+import com.my.relink.domain.item.exchange.ExchangeItem;
+import com.my.relink.domain.like.Like;
+import com.my.relink.domain.like.repository.LikeRepository;
+import com.my.relink.domain.user.User;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class LikeServiceTest {
+    @InjectMocks
+    private LikeService likeService;
+
+    @Mock
+    private LikeRepository likeRepository;
+    @Mock
+    private ExchangeItemService exchangeItemService;
+
+    @Test
+    @DisplayName("찜하기 성공")
+    void testLikeExchangeItem_Success_addLike() {
+        Long userId = 1L;
+        Long itemId = 100L;
+        User user = mock(User.class);
+        ExchangeItem exchangeItem = mock(ExchangeItem.class);
+
+        when(exchangeItemService.getValidUser(userId)).thenReturn(user);
+        when(exchangeItemService.findByIdOrFail(itemId)).thenReturn(exchangeItem);
+        when(likeRepository.findByUserAndExchangeItem(user, exchangeItem)).thenReturn(Optional.empty());
+        Like newLike = Like.builder()
+                .user(user)
+                .exchangeItem(exchangeItem)
+                .id(10L)
+                .build();
+        when(likeRepository.save(any(Like.class))).thenReturn(newLike);
+
+        Long likeId = likeService.toggleLike(userId, itemId);
+
+        assertThat(likeId).isEqualTo(10L);
+        verify(likeRepository, times(1)).save(any(Like.class));
+    }
+
+    @Test
+    @DisplayName("찜 해제하기 성공")
+    void testLikeExchangeItem_Success_deleteLike() {
+        Long userId = 1L;
+        Long itemId = 100L;
+        Long likeId = 10L;
+        User user = mock(User.class);
+        ExchangeItem exchangeItem = mock(ExchangeItem.class);
+        Like existingLike = Like.builder()
+                .id(likeId)
+                .user(user)
+                .exchangeItem(exchangeItem)
+                .build();
+
+        when(exchangeItemService.getValidUser(userId)).thenReturn(user);
+        when(exchangeItemService.findByIdOrFail(itemId)).thenReturn(exchangeItem);
+        when(likeRepository.findByUserAndExchangeItem(user, exchangeItem)).thenReturn(Optional.of(existingLike));
+
+        Long deletedLikeId = likeService.toggleLike(userId, itemId);
+
+        assertThat(deletedLikeId).isEqualTo(likeId);
+        verify(likeRepository, times(1)).deleteByUserAndExchangeItem(user, exchangeItem);
+        verify(likeRepository, never()).save(any(Like.class));
+
+    }
+}

--- a/src/test/java/com/my/relink/service/LikeServiceTest.java
+++ b/src/test/java/com/my/relink/service/LikeServiceTest.java
@@ -26,6 +26,8 @@ class LikeServiceTest {
     private LikeRepository likeRepository;
     @Mock
     private ExchangeItemService exchangeItemService;
+    @Mock
+    private UserService userService;
 
     @Test
     @DisplayName("찜하기 성공")
@@ -35,7 +37,7 @@ class LikeServiceTest {
         User user = mock(User.class);
         ExchangeItem exchangeItem = mock(ExchangeItem.class);
 
-        when(exchangeItemService.getValidUser(userId)).thenReturn(user);
+        when(userService.findByIdOrFail(userId)).thenReturn(user);
         when(exchangeItemService.findByIdOrFail(itemId)).thenReturn(exchangeItem);
         when(likeRepository.findByUserAndExchangeItem(user, exchangeItem)).thenReturn(Optional.empty());
         Like newLike = Like.builder()
@@ -65,14 +67,14 @@ class LikeServiceTest {
                 .exchangeItem(exchangeItem)
                 .build();
 
-        when(exchangeItemService.getValidUser(userId)).thenReturn(user);
+        when(userService.findByIdOrFail(userId)).thenReturn(user);
         when(exchangeItemService.findByIdOrFail(itemId)).thenReturn(exchangeItem);
         when(likeRepository.findByUserAndExchangeItem(user, exchangeItem)).thenReturn(Optional.of(existingLike));
 
         Long deletedLikeId = likeService.toggleLike(userId, itemId);
 
         assertThat(deletedLikeId).isEqualTo(likeId);
-        verify(likeRepository, times(1)).deleteByUserAndExchangeItem(user, exchangeItem);
+        verify(likeRepository, times(1)).delete(existingLike);
         verify(likeRepository, never()).save(any(Like.class));
 
     }


### PR DESCRIPTION
## 💫 PR 개요
<!-- PR에 대한 간단한 설명 -->
교환 상품 찜/해제 하기 기능 구현

## 📌 관련 이슈
<!-- 이슈 연결 -->
- Closes #157
- Resolves #24

## 🛠 작업 내용
<!-- 구현한 내용을 자세히 설명 (시나리오나 구현 이유 등) -->
1. 교환상품에 찜을 할 수 있습니다.
3. 해당 유저가 이미 해당 교환상품에 찜을 해둔 경우 찜을 해제할 수 있습니다.
   - 찜 해제하기는 hard delete로 동작합니다.

## 리뷰 요청 사항
<!-- 리뷰어가 특별히 봐주었으면 하는 부분을 작성! -->

## 체크리스트
<!-- PR을 생성하기 전에 확인해야 할 사항들 -->
- [x] 코드 컨벤션을 준수하였습니다
- [x] 커밋 메시지를 컨벤션에 맞게 작성하였습니다
- [x] conflict가 모두 해결되었습니다
- [x] 테스트 코드를 작성하였습니다
- [x] self review를 진행하였습니다