### PR TITLE
FEAT: 포인트 사용 내역 조회

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,7 +35,6 @@ out/
 
 ### VS Code ###
 .vscode/
-ReLinkApplication.java
 application-local.yaml
 *.env
 .env

--- a/src/main/java/com/my/relink/ReLinkApplication.java
+++ b/src/main/java/com/my/relink/ReLinkApplication.java
@@ -1,0 +1,11 @@
+package com.my.relink;
+
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+public class ReLinkApplication {
+
+    public static void main(String[] args) {
+
+    }
+}

--- a/src/main/java/com/my/relink/config/security/JwtAuthorizationFilter.java
+++ b/src/main/java/com/my/relink/config/security/JwtAuthorizationFilter.java
@@ -45,6 +45,6 @@ public class JwtAuthorizationFilter extends OncePerRequestFilter {
 
     private boolean isTestEndpoint(HttpServletRequest request) {
         String uri = request.getRequestURI();
-        return uri.contains("charge") || uri.contains("/favicon.ico") ||uri.contains("point");
+        return uri.contains("charge") || uri.contains("/favicon.ico") ||uri.contains("payment");
     }
 }

--- a/src/main/java/com/my/relink/config/security/config/SecurityConfig.java
+++ b/src/main/java/com/my/relink/config/security/config/SecurityConfig.java
@@ -53,7 +53,7 @@ public class SecurityConfig {
                 .authorizeHttpRequests(auth -> {
                     auth
                             .dispatcherTypeMatchers(DispatcherType.FORWARD, DispatcherType.ERROR).permitAll()
-                            .requestMatchers("/auth/**", "/chats/**", "/charge-success", "/charge/**", "/charge/users/**", "/charge-form", "/users/point", "/charge-fail").permitAll()
+                            .requestMatchers("/auth/**", "/chats/**", "/charge-success", "/charge/**", "/charge/users/**", "/charge-form", "/users/payment", "/charge-fail").permitAll()
                             .requestMatchers(PathRequest.toStaticResources().atCommonLocations()).permitAll() //정적 리소스 허용
                             .requestMatchers("/error").permitAll();
                     if (profileType.equals("dev")) {

--- a/src/main/java/com/my/relink/controller/payment/PaymentController.java
+++ b/src/main/java/com/my/relink/controller/payment/PaymentController.java
@@ -16,7 +16,7 @@ public class PaymentController {
 
     private final PaymentProcessService paymentServiceFacade;
 
-    @PostMapping("/users/point")
+    @PostMapping("/users/payment")
     public ResponseEntity<PaymentRespDto> confirmPaymentForPointCharge(@RequestBody @Valid PaymentReqDto paymentReqDto){
         return ResponseEntity.ok(paymentServiceFacade.processPayment(paymentReqDto));
     }

--- a/src/main/java/com/my/relink/controller/point/PointController.java
+++ b/src/main/java/com/my/relink/controller/point/PointController.java
@@ -1,0 +1,29 @@
+package com.my.relink.controller.point;
+
+import com.my.relink.config.security.AuthUser;
+import com.my.relink.controller.point.dto.response.PointUsageHistoryRespDto;
+import com.my.relink.service.PointHistoryService;
+import com.my.relink.util.api.ApiResult;
+import com.my.relink.util.page.PageResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+public class PointController {
+
+    private final PointHistoryService pointHistoryService;
+
+    @GetMapping("/users/point/history/usage")
+    public ResponseEntity<ApiResult<PageResponse<PointUsageHistoryRespDto>>> getPointUsageHistories(
+                                                    @RequestParam(required = false, defaultValue = "0") int page,
+                                                    @RequestParam(required = false, defaultValue = "10") int size,
+                                                    @AuthenticationPrincipal AuthUser authUser){
+        return ResponseEntity.ok(ApiResult.success(pointHistoryService.getPointUsageHistories(authUser.getId(), page, size)));
+    }
+
+}

--- a/src/main/java/com/my/relink/controller/point/PointController.java
+++ b/src/main/java/com/my/relink/controller/point/PointController.java
@@ -5,23 +5,28 @@ import com.my.relink.controller.point.dto.response.PointUsageHistoryRespDto;
 import com.my.relink.service.PointHistoryService;
 import com.my.relink.util.api.ApiResult;
 import com.my.relink.util.page.PageResponse;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.PositiveOrZero;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequiredArgsConstructor
+@Validated
 public class PointController {
 
     private final PointHistoryService pointHistoryService;
 
     @GetMapping("/users/point/history/usage")
     public ResponseEntity<ApiResult<PageResponse<PointUsageHistoryRespDto>>> getPointUsageHistories(
-                                                    @RequestParam(required = false, defaultValue = "0") int page,
-                                                    @RequestParam(required = false, defaultValue = "10") int size,
+                                                    @RequestParam(required = false, defaultValue = "0") @PositiveOrZero int page,
+                                                    @RequestParam(required = false, defaultValue = "10") @Min(1) @Max(100) int size,
                                                     @AuthenticationPrincipal AuthUser authUser){
         return ResponseEntity.ok(ApiResult.success(pointHistoryService.getPointUsageHistories(authUser.getId(), page, size)));
     }

--- a/src/main/java/com/my/relink/controller/point/dto/response/PointUsageHistoryRespDto.java
+++ b/src/main/java/com/my/relink/controller/point/dto/response/PointUsageHistoryRespDto.java
@@ -3,39 +3,37 @@ package com.my.relink.controller.point.dto.response;
 import com.my.relink.domain.trade.TradeStatus;
 import com.my.relink.util.DateTimeUtil;
 import com.my.relink.util.page.PageResponse;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 import java.time.LocalDateTime;
 
 @NoArgsConstructor
 @Getter
+@ToString
 public class PointUsageHistoryRespDto {
 
     private Long tradeId;
     private String partnerExchangeItemName;
     private String tradeStatus;
+    @Setter
     private Integer depositAmount;
+    @Setter
     private Integer refundAmount;
+    @Setter
     private String depositDateTime;
+    @Setter
     private String refundDateTime;
-    private LocalDateTime depositLocalDateTime;
-    private LocalDateTime refundLocalDateTime;
+
 
     @Builder
-    public PointUsageHistoryRespDto(Long tradeId, String partnerExchangeItemName, TradeStatus tradeStatus, Integer depositAmount, Integer refundAmount, LocalDateTime depositLocalDateTime, LocalDateTime refundLocalDateTime) {
+    public PointUsageHistoryRespDto(Long tradeId, String partnerExchangeItemName, String tradeStatus, Integer depositAmount, Integer refundAmount, String depositDateTime, String refundDateTime) {
         this.tradeId = tradeId;
         this.partnerExchangeItemName = partnerExchangeItemName;
-        this.tradeStatus = tradeStatus.getMessage();
+        this.tradeStatus = tradeStatus;
         this.depositAmount = depositAmount;
         this.refundAmount = refundAmount;
-        this.depositLocalDateTime= depositLocalDateTime;
-        this.refundLocalDateTime = refundLocalDateTime;
+        this.depositDateTime = depositDateTime;
+        this.refundDateTime = refundDateTime;
     }
 
-    public void formatDateTime(DateTimeUtil dateTimeUtil){
-        this.depositDateTime = dateTimeUtil.getUsagePointHistoryFormattedTime(depositLocalDateTime);
-        this.refundDateTime = dateTimeUtil.getUsagePointHistoryFormattedTime(refundLocalDateTime);
-    }
 }

--- a/src/main/java/com/my/relink/controller/point/dto/response/PointUsageHistoryRespDto.java
+++ b/src/main/java/com/my/relink/controller/point/dto/response/PointUsageHistoryRespDto.java
@@ -1,0 +1,41 @@
+package com.my.relink.controller.point.dto.response;
+
+import com.my.relink.domain.trade.TradeStatus;
+import com.my.relink.util.DateTimeUtil;
+import com.my.relink.util.page.PageResponse;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@NoArgsConstructor
+@Getter
+public class PointUsageHistoryRespDto {
+
+    private Long tradeId;
+    private String partnerExchangeItemName;
+    private String tradeStatus;
+    private Integer depositAmount;
+    private Integer refundAmount;
+    private String depositDateTime;
+    private String refundDateTime;
+    private LocalDateTime depositLocalDateTime;
+    private LocalDateTime refundLocalDateTime;
+
+    @Builder
+    public PointUsageHistoryRespDto(Long tradeId, String partnerExchangeItemName, TradeStatus tradeStatus, Integer depositAmount, Integer refundAmount, LocalDateTime depositLocalDateTime, LocalDateTime refundLocalDateTime) {
+        this.tradeId = tradeId;
+        this.partnerExchangeItemName = partnerExchangeItemName;
+        this.tradeStatus = tradeStatus.getMessage();
+        this.depositAmount = depositAmount;
+        this.refundAmount = refundAmount;
+        this.depositLocalDateTime= depositLocalDateTime;
+        this.refundLocalDateTime = refundLocalDateTime;
+    }
+
+    public void formatDateTime(DateTimeUtil dateTimeUtil){
+        this.depositDateTime = dateTimeUtil.getUsagePointHistoryFormattedTime(depositLocalDateTime);
+        this.refundDateTime = dateTimeUtil.getUsagePointHistoryFormattedTime(refundLocalDateTime);
+    }
+}

--- a/src/main/java/com/my/relink/domain/point/pointHistory/repository/PointHistoryCustomRepository.java
+++ b/src/main/java/com/my/relink/domain/point/pointHistory/repository/PointHistoryCustomRepository.java
@@ -1,0 +1,2 @@
+package com.my.relink.domain.point.pointHistory.repository;public interface PointHistoryCustomRepository {
+}

--- a/src/main/java/com/my/relink/domain/point/pointHistory/repository/PointHistoryCustomRepository.java
+++ b/src/main/java/com/my/relink/domain/point/pointHistory/repository/PointHistoryCustomRepository.java
@@ -1,2 +1,9 @@
-package com.my.relink.domain.point.pointHistory.repository;public interface PointHistoryCustomRepository {
+package com.my.relink.domain.point.pointHistory.repository;
+
+import com.my.relink.controller.point.dto.response.PointUsageHistoryRespDto;
+import com.my.relink.domain.user.User;
+import com.my.relink.util.page.PageResponse;
+
+public interface PointHistoryCustomRepository {
+    PageResponse<PointUsageHistoryRespDto> findPointUsageHistories(User user, int page, int size);
 }

--- a/src/main/java/com/my/relink/domain/point/pointHistory/repository/PointHistoryCustomRepositoryImpl.java
+++ b/src/main/java/com/my/relink/domain/point/pointHistory/repository/PointHistoryCustomRepositoryImpl.java
@@ -1,0 +1,2 @@
+package com.my.relink.domain.point.pointHistory.repository;public class PointHistoryCustomRepositoryImpl {
+}

--- a/src/main/java/com/my/relink/domain/point/pointHistory/repository/PointHistoryCustomRepositoryImpl.java
+++ b/src/main/java/com/my/relink/domain/point/pointHistory/repository/PointHistoryCustomRepositoryImpl.java
@@ -1,2 +1,107 @@
-package com.my.relink.domain.point.pointHistory.repository;public class PointHistoryCustomRepositoryImpl {
+package com.my.relink.domain.point.pointHistory.repository;
+
+import com.my.relink.controller.point.dto.response.PointUsageHistoryRespDto;
+import com.my.relink.domain.point.pointHistory.PointTransactionType;
+import com.my.relink.domain.point.pointHistory.QPointHistory;
+import com.my.relink.domain.trade.QTrade;
+import com.my.relink.domain.user.User;
+import com.my.relink.util.DateTimeUtil;
+import com.my.relink.util.page.PageInfo;
+import com.my.relink.util.page.PageResponse;
+import com.querydsl.core.types.Projections;
+import com.querydsl.core.types.dsl.CaseBuilder;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static com.my.relink.domain.point.pointHistory.QPointHistory.*;
+import static com.my.relink.domain.trade.QTrade.*;
+
+@Repository
+@RequiredArgsConstructor
+public class PointHistoryCustomRepositoryImpl implements PointHistoryCustomRepository{
+
+    private final JPAQueryFactory queryFactory;
+    private final DateTimeUtil dateTimeUtil;
+    @Override
+    public PageResponse<PointUsageHistoryRespDto> findPointUsageHistories(User user, int page, int size) {
+        QTrade t = trade;
+        QPointHistory ph = pointHistory;
+
+        List<PointUsageHistoryRespDto> contents = queryFactory
+                .select(Projections.constructor(PointUsageHistoryRespDto.class,
+                        t.id,
+                        new CaseBuilder()
+                                .when(t.requester.eq(user))
+                                .then(t.ownerExchangeItem.name)
+                                .otherwise(t.requesterExchangeItem.name),
+                        t.tradeStatus,
+                        new CaseBuilder()
+                                .when(ph.pointTransactionType.eq(PointTransactionType.DEPOSIT))
+                                .then(ph.amount.multiply(-1))
+                                .otherwise((Integer) null),
+                        new CaseBuilder()
+                                .when(ph.pointTransactionType.eq(PointTransactionType.RETURN))
+                                .then(ph.amount)
+                                .otherwise((Integer) null),
+                        new CaseBuilder()
+                                .when(ph.pointTransactionType.eq(PointTransactionType.DEPOSIT))
+                                .then(ph.createdAt)
+                                .otherwise((LocalDateTime) null),
+                        new CaseBuilder()
+                                .when(ph.pointTransactionType.eq(PointTransactionType.RETURN))
+                                .then(ph.createdAt)
+                                .otherwise((LocalDateTime) null)
+                ))
+                .from(ph)
+                .join(ph.trade, t)
+                .where(
+                        ph.point.user.eq(user)
+                                .and(ph.pointTransactionType.in(
+                                        PointTransactionType.DEPOSIT,
+                                        PointTransactionType.RETURN
+                                ))
+                ).groupBy(
+                        t.id,
+                        t.tradeStatus,
+                        t.requesterExchangeItem.name,
+                        t.ownerExchangeItem.name,
+                        t.requester.id
+                )
+                .orderBy(ph.createdAt.desc())
+                .offset((long) page * size)
+                .limit(size)
+                .fetch();
+
+
+        contents.forEach(content -> content.formatDateTime(dateTimeUtil));
+
+        Long totalCount = queryFactory
+                .select(t.countDistinct())
+                .from(ph)
+                .join(ph.trade, t)
+                .where(
+                        ph.point.user.eq(user)
+                                .and(ph.pointTransactionType.in(
+                                        PointTransactionType.DEPOSIT,
+                                        PointTransactionType.RETURN
+                                ))
+                )
+                .fetchOne();
+
+        long count = totalCount != null ? totalCount : 0L;
+        int totalPages = (int) Math.ceil((double) count / size);
+
+        return new PageResponse<>(
+                contents,
+                new PageInfo(
+                        totalPages,
+                        count,
+                        page > 0,
+                        page + 1 < totalPages)
+        );
+    }
 }

--- a/src/main/java/com/my/relink/domain/point/pointHistory/repository/PointHistoryCustomRepositoryImpl.java
+++ b/src/main/java/com/my/relink/domain/point/pointHistory/repository/PointHistoryCustomRepositoryImpl.java
@@ -44,7 +44,7 @@ public class PointHistoryCustomRepositoryImpl implements PointHistoryCustomRepos
 
 
     private PageInfo getPointUsagePageInfo(User user, int page, int size){
-        Long totalCount = queryFactory
+        long totalCount = queryFactory
                 .select(pointHistory.trade.countDistinct())
                 .from(pointHistory)
                 .where(
@@ -56,12 +56,11 @@ public class PointHistoryCustomRepositoryImpl implements PointHistoryCustomRepos
                 )
                 .fetchOne();
 
-        long count = totalCount != null ? totalCount : 0L;
-        int totalPages = (int) Math.ceil((double) count / size);
+        int totalPages = (int) Math.ceil((double) totalCount / size);
 
         return new PageInfo (
                 totalPages,
-                count,
+                totalCount,
                 page > 0,
                 page + 1 < totalPages);
     }

--- a/src/main/java/com/my/relink/domain/point/pointHistory/repository/PointHistoryCustomRepositoryImpl.java
+++ b/src/main/java/com/my/relink/domain/point/pointHistory/repository/PointHistoryCustomRepositoryImpl.java
@@ -80,9 +80,8 @@ public class PointHistoryCustomRepositoryImpl implements PointHistoryCustomRepos
         contents.forEach(content -> content.formatDateTime(dateTimeUtil));
 
         Long totalCount = queryFactory
-                .select(t.countDistinct())
+                .select(ph.trade.countDistinct())
                 .from(ph)
-                .join(ph.trade, t)
                 .where(
                         ph.point.user.eq(user)
                                 .and(ph.pointTransactionType.in(

--- a/src/main/java/com/my/relink/domain/point/pointHistory/repository/PointHistoryCustomRepositoryImpl.java
+++ b/src/main/java/com/my/relink/domain/point/pointHistory/repository/PointHistoryCustomRepositoryImpl.java
@@ -12,6 +12,7 @@ import com.my.relink.util.page.PageResponse;
 import com.querydsl.core.Tuple;
 import com.querydsl.core.types.Projections;
 import com.querydsl.core.types.dsl.CaseBuilder;
+import com.querydsl.core.types.dsl.Expressions;
 import com.querydsl.jpa.JPAExpressions;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
@@ -69,12 +70,12 @@ public class PointHistoryCustomRepositoryImpl implements PointHistoryCustomRepos
     private List<PointUsageHistoryRespDto> convertToDto(List<Tuple> pointHistoryTuple, List<Long> tradeIdList){
         Map<Long, PointUsageHistoryRespDto> dtoMap = new LinkedHashMap<>();
         for (Tuple tuple : pointHistoryTuple) {
-            Long tradeId = tuple.get(0, Long.class);
-            TradeStatus tradeStatus = tuple.get(1, TradeStatus.class);
-            String itemName = tuple.get(2, String.class);
-            PointTransactionType type = tuple.get(3, PointTransactionType.class);
-            Integer amount = tuple.get(4, Integer.class);
-            LocalDateTime createdAt = tuple.get(5, LocalDateTime.class);
+            Long tradeId = tuple.get(trade.id);
+            TradeStatus tradeStatus = tuple.get(trade.tradeStatus);
+            String itemName = tuple.get(Expressions.stringPath("itemName"));
+            PointTransactionType type = tuple.get(pointHistory.pointTransactionType);
+            Integer amount = tuple.get(pointHistory.amount);
+            LocalDateTime createdAt = tuple.get(pointHistory.createdAt);
 
             PointUsageHistoryRespDto dto = dtoMap.computeIfAbsent(tradeId, k ->
                     PointUsageHistoryRespDto.builder()
@@ -132,7 +133,7 @@ public class PointHistoryCustomRepositoryImpl implements PointHistoryCustomRepos
                         new CaseBuilder()
                                 .when(trade.requester.eq(user))
                                 .then(trade.ownerExchangeItem.name)
-                                .otherwise(trade.requesterExchangeItem.name),
+                                .otherwise(trade.requesterExchangeItem.name).as("itemName"),
                         pointHistory.pointTransactionType,
                         pointHistory.amount,
                         pointHistory.createdAt

--- a/src/main/java/com/my/relink/domain/point/pointHistory/repository/PointHistoryCustomRepositoryImpl.java
+++ b/src/main/java/com/my/relink/domain/point/pointHistory/repository/PointHistoryCustomRepositoryImpl.java
@@ -4,21 +4,25 @@ import com.my.relink.controller.point.dto.response.PointUsageHistoryRespDto;
 import com.my.relink.domain.point.pointHistory.PointTransactionType;
 import com.my.relink.domain.point.pointHistory.QPointHistory;
 import com.my.relink.domain.trade.QTrade;
+import com.my.relink.domain.trade.TradeStatus;
 import com.my.relink.domain.user.User;
 import com.my.relink.util.DateTimeUtil;
 import com.my.relink.util.page.PageInfo;
 import com.my.relink.util.page.PageResponse;
+import com.querydsl.core.Tuple;
 import com.querydsl.core.types.Projections;
 import com.querydsl.core.types.dsl.CaseBuilder;
+import com.querydsl.jpa.JPAExpressions;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 
 import java.time.LocalDateTime;
-import java.util.List;
+import java.util.*;
 
 import static com.my.relink.domain.point.pointHistory.QPointHistory.*;
 import static com.my.relink.domain.trade.QTrade.*;
+import static com.querydsl.jpa.JPAExpressions.*;
 
 @Repository
 @RequiredArgsConstructor
@@ -31,53 +35,71 @@ public class PointHistoryCustomRepositoryImpl implements PointHistoryCustomRepos
         QTrade t = trade;
         QPointHistory ph = pointHistory;
 
-        List<PointUsageHistoryRespDto> contents = queryFactory
-                .select(Projections.constructor(PointUsageHistoryRespDto.class,
+        List<Tuple> tradeInfoList = queryFactory
+                .select(ph.trade.id, ph.createdAt.max())
+                .from(ph)
+                .where(
+                        ph.point.user.eq(user)
+                                .and(ph.pointTransactionType.in(
+                                        PointTransactionType.RETURN,
+                                        PointTransactionType.DEPOSIT
+                                ))
+                )
+                .groupBy(ph.trade.id)
+                .orderBy(ph.createdAt.max().desc())
+                .offset(page * size)
+                .limit(size)
+                .fetch();
+
+        List<Long> tradeIdList = tradeInfoList.stream()
+                .map(tradeInfo -> tradeInfo.get(0, Long.class))
+                .toList();
+
+        List<Tuple> pointHistoryTuple = queryFactory
+                .select(
                         t.id,
+                        t.tradeStatus,
                         new CaseBuilder()
                                 .when(t.requester.eq(user))
                                 .then(t.ownerExchangeItem.name)
                                 .otherwise(t.requesterExchangeItem.name),
-                        t.tradeStatus,
-                        new CaseBuilder()
-                                .when(ph.pointTransactionType.eq(PointTransactionType.DEPOSIT))
-                                .then(ph.amount.multiply(-1))
-                                .otherwise((Integer) null),
-                        new CaseBuilder()
-                                .when(ph.pointTransactionType.eq(PointTransactionType.RETURN))
-                                .then(ph.amount)
-                                .otherwise((Integer) null),
-                        new CaseBuilder()
-                                .when(ph.pointTransactionType.eq(PointTransactionType.DEPOSIT))
-                                .then(ph.createdAt)
-                                .otherwise((LocalDateTime) null),
-                        new CaseBuilder()
-                                .when(ph.pointTransactionType.eq(PointTransactionType.RETURN))
-                                .then(ph.createdAt)
-                                .otherwise((LocalDateTime) null)
-                ))
+                        ph.pointTransactionType,
+                        ph.amount,
+                        ph.createdAt
+                )
                 .from(ph)
                 .join(ph.trade, t)
-                .where(
-                        ph.point.user.eq(user)
-                                .and(ph.pointTransactionType.in(
-                                        PointTransactionType.DEPOSIT,
-                                        PointTransactionType.RETURN
-                                ))
-                ).groupBy(
-                        t.id,
-                        t.tradeStatus,
-                        t.requesterExchangeItem.name,
-                        t.ownerExchangeItem.name,
-                        t.requester.id
-                )
-                .orderBy(ph.createdAt.desc())
-                .offset((long) page * size)
-                .limit(size)
+                .where(t.id.in(tradeIdList))
                 .fetch();
 
+        Map<Long, PointUsageHistoryRespDto> dtoMap = new LinkedHashMap<>();
+        for (Tuple tuple : pointHistoryTuple) {
+            Long tradeId = tuple.get(0, Long.class);
+            TradeStatus tradeStatus = tuple.get(1, TradeStatus.class);
+            String itemName = tuple.get(2, String.class);
+            PointTransactionType type = tuple.get(3, PointTransactionType.class);
+            Integer amount = tuple.get(4, Integer.class);
+            LocalDateTime createdAt = tuple.get(5, LocalDateTime.class);
 
-        contents.forEach(content -> content.formatDateTime(dateTimeUtil));
+            PointUsageHistoryRespDto dto = dtoMap.computeIfAbsent(tradeId, k ->
+                    PointUsageHistoryRespDto.builder()
+                            .tradeId(tradeId)
+                            .tradeStatus(tradeStatus.getMessage())
+                            .partnerExchangeItemName(itemName)
+                            .build());
+
+            if(type == PointTransactionType.DEPOSIT){
+                dto.setDepositAmount(amount * -1);
+                dto.setDepositDateTime(dateTimeUtil.getUsagePointHistoryFormattedTime(createdAt));
+            } else {
+                dto.setRefundAmount(amount);
+                dto.setRefundDateTime(dateTimeUtil.getUsagePointHistoryFormattedTime(createdAt));
+            }
+        }
+
+        List<PointUsageHistoryRespDto> contents = tradeIdList.stream()
+                .map(dtoMap::get)
+                .toList();
 
         Long totalCount = queryFactory
                 .select(ph.trade.countDistinct())

--- a/src/main/java/com/my/relink/domain/point/pointHistory/repository/PointHistoryRepository.java
+++ b/src/main/java/com/my/relink/domain/point/pointHistory/repository/PointHistoryRepository.java
@@ -10,7 +10,7 @@ import org.springframework.stereotype.Repository;
 import java.util.Optional;
 
 @Repository
-public interface PointHistoryRepository extends JpaRepository<PointHistory, Long> {
+public interface PointHistoryRepository extends JpaRepository<PointHistory, Long>, PointHistoryCustomRepository {
     Optional<PointHistory> findFirstByTradeIdOrderByCreatedAtDesc(Long tradeId);
 
     @Query("SELECT ph FROM PointHistory ph " +

--- a/src/main/java/com/my/relink/service/PointHistoryService.java
+++ b/src/main/java/com/my/relink/service/PointHistoryService.java
@@ -1,2 +1,23 @@
-package com.my.relink.service;public class PointHistoryService {
+package com.my.relink.service;
+
+import com.my.relink.controller.point.dto.response.PointUsageHistoryRespDto;
+import com.my.relink.domain.point.pointHistory.repository.PointHistoryRepository;
+import com.my.relink.domain.user.User;
+import com.my.relink.util.page.PageResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class PointHistoryService {
+
+    private final PointHistoryRepository pointHistoryRepository;
+    private final UserService userService;
+
+    public PageResponse<PointUsageHistoryRespDto> getPointUsageHistories(Long userId, int page, int size) {
+        User user = userService.findByIdOrFail(userId);
+        return pointHistoryRepository.findPointUsageHistories(user, page, size);
+    }
 }

--- a/src/main/java/com/my/relink/service/PointHistoryService.java
+++ b/src/main/java/com/my/relink/service/PointHistoryService.java
@@ -1,0 +1,2 @@
+package com.my.relink.service;public class PointHistoryService {
+}

--- a/src/main/java/com/my/relink/util/DateTimeUtil.java
+++ b/src/main/java/com/my/relink/util/DateTimeUtil.java
@@ -27,6 +27,13 @@ public class DateTimeUtil {
     private static final DateTimeFormatter EXCHANGE_START_DATE_FORMAT =
             DateTimeFormatter.ofPattern("yyyy-MM-dd");
 
+    private static final DateTimeFormatter USAGE_POINT_HISTORY_FORMATTER =
+            DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm");
+
+    public String getUsagePointHistoryFormattedTime(LocalDateTime createdAt){
+        return createdAt != null? createdAt.format(USAGE_POINT_HISTORY_FORMATTER) : "-";
+    }
+
     public String getExchangeStartFormattedTime(LocalDateTime createdAt){
         return createdAt != null? createdAt.format(EXCHANGE_START_DATE_FORMAT) : "-";
     }

--- a/src/test/java/com/my/relink/domain/point/pointHistory/repository/PointHistoryRepositoryTest.java
+++ b/src/test/java/com/my/relink/domain/point/pointHistory/repository/PointHistoryRepositoryTest.java
@@ -1,4 +1,145 @@
+package com.my.relink.domain.point.pointHistory.repository;
+
+import com.my.relink.controller.point.dto.response.PointUsageHistoryRespDto;
+import com.my.relink.domain.item.exchange.ExchangeItem;
+import com.my.relink.domain.item.exchange.repository.ExchangeItemRepository;
+import com.my.relink.domain.point.Point;
+import com.my.relink.domain.point.pointHistory.PointHistory;
+import com.my.relink.domain.point.pointHistory.PointTransactionType;
+import com.my.relink.domain.point.repository.PointRepository;
+import com.my.relink.domain.trade.Trade;
+import com.my.relink.domain.trade.TradeStatus;
+import com.my.relink.domain.trade.repository.TradeRepository;
+import com.my.relink.domain.user.User;
+import com.my.relink.domain.user.repository.UserRepository;
+import com.my.relink.service.UserService;
+import com.my.relink.util.page.PageResponse;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+import static com.mysema.commons.lang.Assert.assertThat;
 import static org.junit.jupiter.api.Assertions.*;
+
+
+@SpringBootTest
+@Transactional
 class PointHistoryRepositoryTest {
-  
+
+    @Autowired
+    private PointHistoryRepository pointHistoryRepository;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private TradeRepository tradeRepository;
+
+    @Autowired
+    private PointRepository pointRepository;
+
+    @Autowired
+    private ExchangeItemRepository exchangeItemRepository;
+
+
+
+    @Test
+    @DisplayName("포인트 사용 내역 조회: 각각의 거래건에 대해 보증금 예치/환급 내역이 정상 조회되어야 한다")
+    void findPointUsageHistories() {
+        User requester = createAndSaveUser("requester");
+        User owner = createAndSaveUser("owner");
+
+        Point requesterPoint = createAndSavePoint(requester);
+
+        ExchangeItem requesterItem = createAndSaveExchangeItem("아이템1", requester);
+        ExchangeItem ownerItem = createAndSaveExchangeItem("아이템2", owner);
+
+        Trade trade1 = createAndSaveTrade(requester, owner, requesterItem, ownerItem);
+        createAndSavePointHistory(trade1, requesterPoint, 1000, PointTransactionType.DEPOSIT);
+        createAndSavePointHistory(trade1, requesterPoint, 1000, PointTransactionType.RETURN);
+
+        Trade trade2 = createAndSaveTrade(owner, requester, ownerItem, requesterItem);
+        createAndSavePointHistory(trade2, requesterPoint, 2000, PointTransactionType.DEPOSIT);
+
+        PageResponse<PointUsageHistoryRespDto> result = pointHistoryRepository.findPointUsageHistories(requester, 0, 10);
+
+        List<PointUsageHistoryRespDto> content = result.getContent();
+        for (PointUsageHistoryRespDto pointUsageHistoryRespDto : content) {
+            System.out.println("pointUsageHistoryRespDto = " + pointUsageHistoryRespDto);
+        }
+
+
+        assertEquals(result.getContent().size(), 2);
+        assertEquals(result.getPageInfo().getTotalCount(), 2);
+
+        // 최신순 정렬이므로 trade2가 먼저나와야 함
+        PointUsageHistoryRespDto trade2History = result.getContent().get(0);
+        assertEquals(trade2History.getTradeId(), trade2.getId());
+        assertEquals(trade2History.getPartnerExchangeItemName(), ownerItem.getName());
+        assertEquals(trade2History.getDepositAmount(), -2000);
+        assertNull(trade2History.getRefundAmount());
+
+        PointUsageHistoryRespDto trade1History = result.getContent().get(1);
+        assertEquals(trade1History.getTradeId(), trade1.getId());
+        assertEquals(trade1History.getPartnerExchangeItemName(), ownerItem.getName());
+        assertEquals(trade1History.getDepositAmount(), -1000);
+        assertEquals(trade1History.getRefundAmount(), 1000);
+    }
+
+
+    private User createAndSaveUser(String name) {
+        User user = User.builder()
+                .name(name)
+                .email(name + "@naver.com")
+                .password("password")
+                .build();
+        return userRepository.save(user);
+    }
+
+    private Point createAndSavePoint(User user) {
+        Point point = Point.builder()
+                .user(user)
+                .amount(10000)
+                .build();
+        return pointRepository.save(point);
+    }
+
+    private ExchangeItem createAndSaveExchangeItem(String name, User owner) {
+        ExchangeItem item = ExchangeItem.builder()
+                .name(name)
+                .description("상품입니다")
+                .user(owner)
+                .isDeleted(false)
+                .build();
+        return exchangeItemRepository.save(item);
+    }
+
+    private Trade createAndSaveTrade(User requester, User owner, ExchangeItem requesterItem, ExchangeItem ownerItem) {
+        Trade trade = Trade.builder()
+                .requester(requester)
+                .requesterExchangeItem(requesterItem)
+                .ownerExchangeItem(ownerItem)
+                .tradeStatus(TradeStatus.EXCHANGED)
+                .hasRequesterRequested(true)
+                .hasOwnerRequested(true)
+                .hasOwnerReceived(false)
+                .hasRequesterReceived(false)
+                .build();
+        return tradeRepository.save(trade);
+    }
+
+    private PointHistory createAndSavePointHistory(Trade trade, Point point, int amount, PointTransactionType type) {
+        PointHistory history = PointHistory.builder()
+                .trade(trade)
+                .point(point)
+                .amount(amount)
+                .pointTransactionType(type)
+                .build();
+        return pointHistoryRepository.save(history);
+    }
+
 }

--- a/src/test/java/com/my/relink/domain/point/pointHistory/repository/PointHistoryRepositoryTest.java
+++ b/src/test/java/com/my/relink/domain/point/pointHistory/repository/PointHistoryRepositoryTest.java
@@ -1,0 +1,4 @@
+import static org.junit.jupiter.api.Assertions.*;
+class PointHistoryRepositoryTest {
+  
+}

--- a/src/test/java/com/my/relink/service/PointHistoryServiceTest.java
+++ b/src/test/java/com/my/relink/service/PointHistoryServiceTest.java
@@ -1,4 +1,7 @@
+package com.my.relink.service;
+
 import static org.junit.jupiter.api.Assertions.*;
+
 class PointHistoryServiceTest {
-  
+
 }

--- a/src/test/java/com/my/relink/service/PointHistoryServiceTest.java
+++ b/src/test/java/com/my/relink/service/PointHistoryServiceTest.java
@@ -1,7 +1,76 @@
 package com.my.relink.service;
 
-import static org.junit.jupiter.api.Assertions.*;
+import com.my.relink.controller.point.dto.response.PointUsageHistoryRespDto;
+import com.my.relink.domain.point.pointHistory.repository.PointHistoryRepository;
+import com.my.relink.domain.user.User;
+import com.my.relink.ex.BusinessException;
+import com.my.relink.ex.ErrorCode;
+import com.my.relink.util.page.PageResponse;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.messaging.MessageChannel;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
 class PointHistoryServiceTest {
+
+    @InjectMocks
+    private PointHistoryService pointHistoryService;
+
+    @Mock
+    private PointHistoryRepository pointHistoryRepository;
+
+    @Mock
+    private UserService userService;
+
+    @Nested
+    @DisplayName("포인트 사용 내역 조회 테스트")
+    class GetPointUsageHistories{
+        private User user;
+        private Long userId;
+        private int page = 0;
+        private int size = 10;
+        private PageResponse<PointUsageHistoryRespDto> response;
+
+
+        @Test
+        @DisplayName("포인트 사용 내역 조회에 성공한다")
+        void success(){
+            user = mock(User.class);
+            response = mock(PageResponse.class);
+            when(userService.findByIdOrFail(userId)).thenReturn(user);
+            when(pointHistoryRepository.findPointUsageHistories(user, page, size))
+                    .thenReturn(response);
+
+            PageResponse<PointUsageHistoryRespDto> result = pointHistoryService.getPointUsageHistories(userId, page, size);
+
+            assertThat(result).isEqualTo(response);
+            verify(userService).findByIdOrFail(userId);
+            verify(pointHistoryRepository).findPointUsageHistories(user, page, size);
+        }
+
+        @Test
+        @DisplayName("존재하지 않는 사용자일 경우 예외가 발생한다")
+        void fail_when_userNotFound(){
+            when(userService.findByIdOrFail(userId))
+                    .thenThrow(new BusinessException(ErrorCode.USER_NOT_FOUND));
+
+            assertThatThrownBy(() -> pointHistoryService.getPointUsageHistories(userId, page, size))
+                    .isInstanceOf(BusinessException.class)
+                    .hasFieldOrPropertyWithValue("errorCode", ErrorCode.USER_NOT_FOUND);
+
+            verify(pointHistoryRepository, never()).findPointUsageHistories(any(), anyInt(), anyInt());
+        }
+
+    }
 
 }

--- a/src/test/java/com/my/relink/service/PointHistoryServiceTest.java
+++ b/src/test/java/com/my/relink/service/PointHistoryServiceTest.java
@@ -1,0 +1,4 @@
+import static org.junit.jupiter.api.Assertions.*;
+class PointHistoryServiceTest {
+  
+}


### PR DESCRIPTION
## 💫 PR 개요
유저의 포인트 사용 내역을 조회한다

## 📌 관련 이슈
<!-- 이슈 연결 -->
- Opens #121

## 🛠 작업 내용
* api: users/point/history/usage

1. 유저의 point를 들고 있고, TrasctionType이  DEPOSIT, RETURN인 모든 PointHistory를 조회한다
2. 이 때 한 Trade에 대해 RETURN이 있다면, 해당 Trade에 대해 DEPOSIT된 PointHistory와 그룹화한다
3. 응답 반환

### 테스트
PointHistoryRepository 쿼리 테스트
PointHistoryService
- 정상 케이스
- 존재하지 않는 유저일 때 예외 던지는 케이스

## 리뷰 요청 사항
<!-- 리뷰어가 특별히 봐주었으면 하는 부분을 작성! -->

## 체크리스트
<!-- PR을 생성하기 전에 확인해야 할 사항들 -->
- [x] 코드 컨벤션을 준수하였습니다
- [x] 커밋 메시지를 컨벤션에 맞게 작성하였습니다
- [x] conflict가 모두 해결되었습니다
- [x] 테스트 코드를 작성하였습니다
- [x] self review를 진행하였습니다