### PR TITLE
FEAT: 거래 신고 이미지 저장

### DIFF
--- a/src/main/java/com/my/relink/chat/controller/dto/request/ChatImageReqDto.java
+++ b/src/main/java/com/my/relink/chat/controller/dto/request/ChatImageReqDto.java
@@ -1,5 +1,6 @@
 package com.my.relink.chat.controller.dto.request;
 
+import com.my.relink.common.validation.ValidFile;
 import jakarta.validation.constraints.NotNull;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -13,7 +14,7 @@ import org.springframework.web.multipart.MultipartFile;
 @AllArgsConstructor
 public class ChatImageReqDto {
 
-    @NotNull(message = "이미지를 첨부해야 합니다")
+    @ValidFile(message = "이미지를 첨부해야 합니다")
     private MultipartFile image;
 
 }

--- a/src/main/java/com/my/relink/common/validation/ValidFile.java
+++ b/src/main/java/com/my/relink/common/validation/ValidFile.java
@@ -1,0 +1,18 @@
+package com.my.relink.common.validation;
+
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(value = ElementType.FIELD)
+@Retention(value = RetentionPolicy.RUNTIME)
+@Constraint(validatedBy = ValidFileValidator.class)
+public @interface ValidFile {
+    String message() default "유효한 파일이 아닙니다";
+    Class<?>[] groups() default {};
+    Class<? extends Payload>[] payload() default {};
+}

--- a/src/main/java/com/my/relink/common/validation/ValidFileValidator.java
+++ b/src/main/java/com/my/relink/common/validation/ValidFileValidator.java
@@ -1,0 +1,12 @@
+package com.my.relink.common.validation;
+
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
+import org.springframework.web.multipart.MultipartFile;
+
+public class ValidFileValidator implements ConstraintValidator<ValidFile, MultipartFile> {
+    @Override
+    public boolean isValid(MultipartFile multipartFile, ConstraintValidatorContext constraintValidatorContext) {
+        return multipartFile != null && !multipartFile.isEmpty();
+    }
+}

--- a/src/main/java/com/my/relink/controller/report/ReportController.java
+++ b/src/main/java/com/my/relink/controller/report/ReportController.java
@@ -3,13 +3,14 @@ package com.my.relink.controller.report;
 import com.my.relink.config.security.AuthUser;
 import com.my.relink.controller.report.dto.request.ExchangeItemReportCreateReqDto;
 import com.my.relink.controller.report.dto.request.TradeReportCreateReqDto;
+import com.my.relink.controller.report.dto.request.UploadImagesForReportReqDto;
 import com.my.relink.controller.report.dto.response.ExchangeItemInfoRespDto;
 import com.my.relink.controller.report.dto.response.TradeInfoRespDto;
+import com.my.relink.controller.report.dto.response.UploadImagesForReportRespDto;
 import com.my.relink.service.ReportService;
 import com.my.relink.util.api.ApiResult;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import org.apache.coyote.Response;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
@@ -19,6 +20,14 @@ import org.springframework.web.bind.annotation.*;
 public class ReportController {
 
     private final ReportService reportService;
+
+
+    @PostMapping("/trades/{tradeId}/report/images")
+    public ResponseEntity<ApiResult<UploadImagesForReportRespDto>> uploadTradeReportImages(@PathVariable("tradeId") Long tradeId,
+                                                                                           @ModelAttribute @Valid UploadImagesForReportReqDto uploadImagesForReportReqDto,){
+        return ResponseEntity.ok(ApiResult.success(reportService.uploadImagesForTradeReport(tradeId, uploadImagesForReportReqDto)));
+    }
+
 
     @GetMapping("/items/exchanges/{itemId}/report")
     public ResponseEntity<ApiResult<ExchangeItemInfoRespDto>> getExchangeItemInfoForReport(@PathVariable("itemId") Long itemId){

--- a/src/main/java/com/my/relink/controller/report/ReportController.java
+++ b/src/main/java/com/my/relink/controller/report/ReportController.java
@@ -11,6 +11,7 @@ import com.my.relink.service.ReportService;
 import com.my.relink.util.api.ApiResult;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
@@ -22,9 +23,9 @@ public class ReportController {
     private final ReportService reportService;
 
 
-    @PostMapping("/trades/{tradeId}/report/images")
+    @PostMapping(value = "/trades/{tradeId}/report/images", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     public ResponseEntity<ApiResult<UploadImagesForReportRespDto>> uploadTradeReportImages(@PathVariable("tradeId") Long tradeId,
-                                                                                           @ModelAttribute @Valid UploadImagesForReportReqDto uploadImagesForReportReqDto,){
+                                                                                           @ModelAttribute @Valid UploadImagesForReportReqDto uploadImagesForReportReqDto){
         return ResponseEntity.ok(ApiResult.success(reportService.uploadImagesForTradeReport(tradeId, uploadImagesForReportReqDto)));
     }
 

--- a/src/main/java/com/my/relink/controller/report/dto/request/UploadImagesForReportReqDto.java
+++ b/src/main/java/com/my/relink/controller/report/dto/request/UploadImagesForReportReqDto.java
@@ -1,0 +1,19 @@
+package com.my.relink.controller.report.dto.request;
+
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.web.multipart.MultipartFile;
+
+@AllArgsConstructor
+@Getter
+public class UploadImagesForReportReqDto {
+    @NotNull(message = "이미지를 첨부해야 합니다")
+    private MultipartFile image1;
+    private MultipartFile image2;
+    private MultipartFile image3;
+    private MultipartFile image4;
+    private MultipartFile image5;
+    private MultipartFile image6;
+    private MultipartFile image7;
+}

--- a/src/main/java/com/my/relink/controller/report/dto/request/UploadImagesForReportReqDto.java
+++ b/src/main/java/com/my/relink/controller/report/dto/request/UploadImagesForReportReqDto.java
@@ -5,6 +5,10 @@ import lombok.AllArgsConstructor;
 import lombok.Getter;
 import org.springframework.web.multipart.MultipartFile;
 
+import java.util.List;
+import java.util.Objects;
+import java.util.stream.Stream;
+
 @AllArgsConstructor
 @Getter
 public class UploadImagesForReportReqDto {
@@ -16,4 +20,17 @@ public class UploadImagesForReportReqDto {
     private MultipartFile image5;
     private MultipartFile image6;
     private MultipartFile image7;
+
+    public List<MultipartFile> getNonNullImages() {
+        return Stream.of(
+                        image1,
+                        image2,
+                        image3,
+                        image4,
+                        image5,
+                        image6,
+                        image7)
+                .filter(Objects::nonNull)
+                .toList();
+    }
 }

--- a/src/main/java/com/my/relink/controller/report/dto/request/UploadImagesForReportReqDto.java
+++ b/src/main/java/com/my/relink/controller/report/dto/request/UploadImagesForReportReqDto.java
@@ -1,8 +1,9 @@
 package com.my.relink.controller.report.dto.request;
 
-import jakarta.validation.constraints.NotNull;
+import com.my.relink.common.validation.ValidFile;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
+import org.springframework.util.StringUtils;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.util.List;
@@ -12,7 +13,7 @@ import java.util.stream.Stream;
 @AllArgsConstructor
 @Getter
 public class UploadImagesForReportReqDto {
-    @NotNull(message = "이미지를 첨부해야 합니다")
+    @ValidFile(message = "이미지를 첨부해야 합니다")
     private MultipartFile image1;
     private MultipartFile image2;
     private MultipartFile image3;
@@ -31,6 +32,7 @@ public class UploadImagesForReportReqDto {
                         image6,
                         image7)
                 .filter(Objects::nonNull)
+                .filter(file -> StringUtils.hasText(file.getOriginalFilename()))
                 .toList();
     }
 }

--- a/src/main/java/com/my/relink/controller/report/dto/response/UploadImagesForReportRespDto.java
+++ b/src/main/java/com/my/relink/controller/report/dto/response/UploadImagesForReportRespDto.java
@@ -1,0 +1,17 @@
+package com.my.relink.controller.report.dto.response;
+
+import com.my.relink.domain.report.Report;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor
+@Getter
+public class UploadImagesForReportRespDto {
+
+    private Long reportId;
+
+    public UploadImagesForReportRespDto(Report report) {
+        this.reportId = report.getId();
+    }
+}

--- a/src/main/java/com/my/relink/domain/report/repository/ReportRepository.java
+++ b/src/main/java/com/my/relink/domain/report/repository/ReportRepository.java
@@ -9,4 +9,6 @@ import java.util.Optional;
 public interface ReportRepository extends JpaRepository<Report, Long> {
 
     Optional<Report> findByEntityIdAndReportTypeAndTargetUserId(Long entityId, ReportType reportType, Long targetUserId);
+
+    Optional<Report> findByEntityIdAndReportType(Long entityId, ReportType reportType);
 }

--- a/src/main/java/com/my/relink/ex/ErrorCode.java
+++ b/src/main/java/com/my/relink/ex/ErrorCode.java
@@ -64,10 +64,10 @@ public enum ErrorCode {
     IMAGE_ACCESS_DENIED(HttpStatus.BAD_REQUEST.value(), "해당 이미지의 소유자와 다릅니다."),
     INVALID_FILE_URL(HttpStatus.BAD_REQUEST.value(), "파일 URL 이 비어있습니다."),
     ITEM_IN_EXCHANGE(HttpStatus.BAD_REQUEST.value(), "해당 상품이 거래중입니다."),
-    DONATION_ITEM_NOT_FOUND(HttpStatus.INTERNAL_SERVER_ERROR.value(), "해당 기부 상품을 찾을 수 없습니다.")
+    DONATION_ITEM_NOT_FOUND(HttpStatus.INTERNAL_SERVER_ERROR.value(), "해당 기부 상품을 찾을 수 없습니다."),
+    REPORT_NOR_FOUND(HttpStatus.NOT_FOUND.value(), "해당 신고를 찾을 수 없습니다"),
+    IMAGE_UPLOAD_FAILED(HttpStatus.INTERNAL_SERVER_ERROR.value(), "외부 스토리지 이미지 업로드에 실패했습니다");
 
-
-    ;
     private final int status;
     private final String message;
 

--- a/src/main/java/com/my/relink/service/ImageService.java
+++ b/src/main/java/com/my/relink/service/ImageService.java
@@ -26,6 +26,12 @@ public class ImageService {
     private final ImageRepository imageRepository;
     private final S3Service s3Service;
 
+    @Transactional
+    public void saveImages(List<Image> imageList){
+        imageRepository.saveAll(imageList);
+    }
+
+
     public String getExchangeItemThumbnailUrl(ExchangeItem exchangeItem){
         return imageRepository.findTopByEntityIdAndEntityTypeOrderByCreatedAtAsc(
                         exchangeItem.getId(),

--- a/src/main/java/com/my/relink/service/ReportService.java
+++ b/src/main/java/com/my/relink/service/ReportService.java
@@ -1,12 +1,18 @@
 package com.my.relink.service;
 
 
+import com.my.relink.config.s3.S3Service;
 import com.my.relink.controller.report.dto.request.ExchangeItemReportCreateReqDto;
 import com.my.relink.controller.report.dto.request.TradeReportCreateReqDto;
+import com.my.relink.controller.report.dto.request.UploadImagesForReportReqDto;
 import com.my.relink.controller.report.dto.response.ExchangeItemInfoRespDto;
 import com.my.relink.controller.report.dto.response.TradeInfoRespDto;
+import com.my.relink.controller.report.dto.response.UploadImagesForReportRespDto;
+import com.my.relink.domain.image.EntityType;
+import com.my.relink.domain.image.Image;
 import com.my.relink.domain.item.exchange.ExchangeItem;
 import com.my.relink.domain.item.exchange.repository.ExchangeItemRepository;
+import com.my.relink.domain.report.Report;
 import com.my.relink.domain.report.ReportType;
 import com.my.relink.domain.report.repository.ReportRepository;
 import com.my.relink.domain.trade.Trade;
@@ -15,12 +21,20 @@ import com.my.relink.ex.BusinessException;
 import com.my.relink.ex.ErrorCode;
 import com.my.relink.util.DateTimeUtil;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ProblemDetail;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import java.util.stream.Stream;
 
 @Service
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
+@Slf4j
 public class ReportService {
 
     private final TradeService tradeService;
@@ -29,6 +43,7 @@ public class ReportService {
     private final DateTimeUtil dateTimeUtil;
     private final ImageService imageService;
     private final ExchangeItemRepository exchangeItemRepository;
+    private final S3Service s3Service;
 
     @Transactional
     public void createTradeReport(Long tradeId, Long userId, TradeReportCreateReqDto tradeReportCreateReqDto) {
@@ -78,5 +93,59 @@ public class ReportService {
         ExchangeItem exchangeItem = exchangeItemService.findByIdFetchUser(itemId);
         String exchangeItemUrl = imageService.getExchangeItemThumbnailUrl(exchangeItem);
         return new ExchangeItemInfoRespDto(exchangeItem, exchangeItemUrl);
+    }
+
+    @Transactional
+    public UploadImagesForReportRespDto uploadImagesForTradeReport(Long tradeId, UploadImagesForReportReqDto uploadImagesForReportReqDto) {
+        Report report = reportRepository.findByEntityIdAndReportType(tradeId, ReportType.TRADE)
+                .orElseThrow(() -> new BusinessException(ErrorCode.REPORT_NOR_FOUND));
+        List<Image> imageList = uploadImages(uploadImagesForReportReqDto, report);
+        try {
+            imageService.saveImages(imageList);
+        }catch (Exception e){
+            handleImageUploadFail(imageList);
+            //에러 던지기
+        }
+        return new UploadImagesForReportRespDto(report);
+    }
+
+    private void handleImageUploadFail(List<Image> imageList){
+        for (Image image : imageList) {
+            try {
+                s3Service.deleteImage(image.getImageUrl());
+            } catch (Exception e){
+                log.error("[이미지 삭제 실패] imageUrl = {}, cause = {}", image.getImageUrl(), e.getMessage(), e);
+            }
+        }
+
+    }
+
+    private List<Image> uploadImages(UploadImagesForReportReqDto uploadImagesForReportReqDto, Report report){
+        List<Image> uploadedImages = new ArrayList<>();
+
+        Stream.of(
+                    uploadImagesForReportReqDto.getImage1(),
+                    uploadImagesForReportReqDto.getImage2(),
+                    uploadImagesForReportReqDto.getImage3(),
+                    uploadImagesForReportReqDto.getImage4(),
+                    uploadImagesForReportReqDto.getImage5(),
+                    uploadImagesForReportReqDto.getImage6(),
+                    uploadImagesForReportReqDto.getImage7())
+            .filter(Objects::nonNull)
+            .forEach(file -> {
+                try {
+                    String imageUrl = s3Service.upload(file);
+                    uploadedImages.add(Image.builder()
+                            .entityId(report.getId())
+                            .entityType(EntityType.REPORT)
+                            .imageUrl(imageUrl)
+                            .build());
+                } catch (Exception e) {
+                    handleImageUploadFail(uploadedImages);
+                    throw new BusinessException(ErrorCode.IMAGE_UPLOAD_FAILED);
+                }
+            });
+
+        return uploadedImages;
     }
 }

--- a/src/main/java/com/my/relink/service/ReportService.java
+++ b/src/main/java/com/my/relink/service/ReportService.java
@@ -39,7 +39,6 @@ public class ReportService {
     private final ExchangeItemService exchangeItemService;
     private final DateTimeUtil dateTimeUtil;
     private final ImageService imageService;
-    private final ExchangeItemRepository exchangeItemRepository;
     private final S3Service s3Service;
 
     @Transactional


### PR DESCRIPTION
## 💫 PR 개요
거래 신고 시 첨부한 이미지 저장 기능을 구현한

## 📌 관련 이슈
<!-- 이슈 연결 -->
- Opens #179

## 🛠 작업 내용
거래 신고 시 이미지를 첨부한 경우 다음 순서로 동작합니다:
1) 거래 신고 내역 저장
2) S3에 이미지 업로드 및 DB에 이미지 저장

최대 7개의 이미지를 첨부할 수 있으며
첫 번째 이미지는 필수로 첨부해야 합니다

### 테스트
- 성공 케이스
- 존재하지 않는 신고에 대해 이미지 업로드를 시도하면 예외가 발생하는 케이스
- S3 업로드 실패 시 예외가 발생하고 업로드된 이미지들이 삭제되는 케이스
- 이미지 저장 실패 시 예외가 발생하고 S3에 업로드된 이미지들이 삭제되는 케이스
- 이미지 저장 실패 후 S3 삭제 과정에서 일부 이미지 삭제에 실패하는 케이스


## 리뷰 요청 사항
<!-- 리뷰어가 특별히 봐주었으면 하는 부분을 작성! -->

## 체크리스트
<!-- PR을 생성하기 전에 확인해야 할 사항들 -->
- [x] 코드 컨벤션을 준수하였습니다
- [x] 커밋 메시지를 컨벤션에 맞게 작성하였습니다
- [x] conflict가 모두 해결되었습니다
- [x] 테스트 코드를 작성하였습니다
- [x] self review를 진행하였습니다