### PR TITLE
FEAT: 웹소켓 연결 시 jwt 예외 처리 추가하기

### DIFF
--- a/src/main/java/com/my/relink/chat/handler/StompHandler.java
+++ b/src/main/java/com/my/relink/chat/handler/StompHandler.java
@@ -7,6 +7,7 @@ import com.my.relink.domain.trade.Trade;
 import com.my.relink.domain.trade.TradeStatus;
 import com.my.relink.ex.BusinessException;
 import com.my.relink.ex.ErrorCode;
+import com.my.relink.ex.SecurityFilterChainException;
 import com.my.relink.service.TradeService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -137,7 +138,15 @@ public class StompHandler implements ChannelInterceptor {
      */
     private AuthUser validateToken(StompHeaderAccessor accessor){
         String tokenWithPrefix = accessor.getFirstNativeHeader(WebSocketHeader.AUTH_HEADER);
+        if(tokenWithPrefix == null){
+            throw new BusinessException(ErrorCode.TOKEN_NOT_FOUND);
+        }
         String token = tokenWithPrefix.replace(JwtProvider.TOKEN_PREFIX, "");
+        try{
+            jwtProvider.validateToken(token);
+        } catch (SecurityFilterChainException e){
+            throw new BusinessException(e.getErrorCode());
+        }
         return jwtProvider.getAuthUserForToken(token);
     }
 

--- a/src/test/java/com/my/relink/chat/handler/StompHandlerTest.java
+++ b/src/test/java/com/my/relink/chat/handler/StompHandlerTest.java
@@ -76,6 +76,26 @@ class StompHandlerTest {
     }
 
     @Test
+    @DisplayName("토큰 검증 예외 발생 시 예외를 던진다")
+    void preSend_throw_exception_when_jwt_exception_occurs() throws Exception{
+        String invalidToken = "Bearer " + "invalid_token";
+        StompHeaderAccessor accessor = createStompHeaderAccessor(
+                StompCommand.CONNECT,
+                invalidToken,
+                TradeStatus.EXCHANGED.getMessage());
+        Message<?> connectMessage = MessageBuilder.createMessage(new byte[0], accessor.getMessageHeaders());
+
+        Message<?> resultMessage = stompHandler.preSend(connectMessage, messageChannel);
+
+        StompHeaderAccessor resultAccessor = MessageHeaderAccessor.getAccessor(resultMessage, StompHeaderAccessor.class);
+        assertNotNull(resultAccessor);
+        assertEquals(StompCommand.ERROR, resultAccessor.getCommand());
+        assertEquals(String.valueOf(ErrorCode.INVALID_JWT_TOKEN.getStatus()), resultAccessor.getFirstNativeHeader("status"));
+    }
+
+
+
+    @Test
     @DisplayName("유효한 토큰과 진행중인 거래상태로 연결 시도시 성공한다")
     void preSend_connectWithValidToken_andActiveTradeStatus() throws Exception {
 


### PR DESCRIPTION
## 💫 PR 개요
기존 stomp 핸들러에 jwt 예외 처리 추가

## 📌 관련 이슈
<!-- 이슈 연결 -->
- Opens #182

## 🛠 작업 내용
웹소켓 연결 시 토큰 정보 검증 실패에 따른 예외 처리 추가

## 리뷰 요청 사항
<!-- 리뷰어가 특별히 봐주었으면 하는 부분을 작성! -->

## 체크리스트
<!-- PR을 생성하기 전에 확인해야 할 사항들 -->
- [x] 코드 컨벤션을 준수하였습니다
- [x] 커밋 메시지를 컨벤션에 맞게 작성하였습니다
- [x] conflict가 모두 해결되었습니다
- [x] 테스트 코드를 작성하였습니다
- [x] self review를 진행하였습니다